### PR TITLE
 Update dependencies and improve command handling and query example

### DIFF
--- a/cmd/escuse-me/main.go
+++ b/cmd/escuse-me/main.go
@@ -175,6 +175,7 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 	if !ok {
 		return fmt.Errorf("could not cast commands to ElasticSearchCommand")
 	}
+
 	queriesCommand, err := pkg.NewQueriesCommand(esCommands, aliases)
 	if err != nil {
 		return err

--- a/cmd/escuse-me/queries/examples/simple-search.escuse-me/main.yaml
+++ b/cmd/escuse-me/queries/examples/simple-search.escuse-me/main.yaml
@@ -23,6 +23,9 @@ flags:
       - special_features
       - brand_name
     help: Fields to return from ES index
+  - name: additional_source_fields
+    type: stringList
+    help: Additional fields to return from ES index
   - name: types
     type: stringList
     default:

--- a/cmd/escuse-me/queries/examples/simple-search.escuse-me/query.tmpl.yaml
+++ b/cmd/escuse-me/queries/examples/simple-search.escuse-me/query.tmpl.yaml
@@ -1,5 +1,6 @@
 _source:
 {{ .source_fields | toYaml | indentBlock 2 | trimRightSpace }}
+{{if .additional_source_fields}}{{ .additional_source_fields | toYaml | indentBlock 2 | trimRightSpace }}{{end}}
 from: {{ .from }}
 query:
   bool:

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
-	github.com/go-go-golems/clay v0.0.23
-	github.com/go-go-golems/glazed v0.4.12
+	github.com/go-go-golems/clay v0.0.25
+	github.com/go-go-golems/glazed v0.4.20
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -98,10 +98,10 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.0.23 h1:VJn58b1ZrR87DyKKcoi9eVHeDbfA0kg0EsceFIfgqLA=
-github.com/go-go-golems/clay v0.0.23/go.mod h1:tn4ZWCqBESPOrag12d2yYakqGwriiwrqbn0kP0PuWNw=
-github.com/go-go-golems/glazed v0.4.12 h1:ijUx/yqOg9PFIBU+a4id6EBKTRMN7QzDd166mjZMXus=
-github.com/go-go-golems/glazed v0.4.12/go.mod h1:ORRe+8ZW7S3OTd09QuDhDmDXK1QZBfmfIZUIaoEYqFU=
+github.com/go-go-golems/clay v0.0.25 h1:KrZ5luxWRDIvt78dugTGdog5NWii201fCgfNgQMIN/k=
+github.com/go-go-golems/clay v0.0.25/go.mod h1:KX8IIKGpt9FvbwgcEBVOZfPB22LcdjRhVpjk8sB0SBs=
+github.com/go-go-golems/glazed v0.4.20 h1:ONxcMMSIpBinnxrU71kY3mtO7mmwBs5GJ+ZLmLRA/js=
+github.com/go-go-golems/glazed v0.4.20/go.mod h1:hvndeie5yW10MHq2Z0A8q1TMlqNUFP75i45oDCOTjqs=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=


### PR DESCRIPTION

This pull request includes several updates and improvements:

- The handling of parent commands in directory-based commands has been improved. The changes in `pkg/cmd.go` ensure that the last path element is stripped from the parents, and the parents are correctly passed to the command description options.

- An enhancement has been made to the example command `simple-search.escuse-me`. A new flag `additional_source_fields` has been added, allowing users to specify additional fields to return from the Elasticsearch index. 


---

- :art: Add additional_source_fields to example command
- :ambulance: Properly handle parents for command dir based commands
- :arrow_up: Bump glazed
