### PR TITLE
Add default index configuration and raw results output option

### DIFF
--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -45,6 +45,7 @@ func GetCobraCommandEscuseMeMiddlewares(
 		middlewares.WrapWithWhitelistedLayers(
 			[]string{
 				layers.EsConnectionSlug,
+				layers.ESHelpersSlug,
 			},
 			middlewares.GatherFlagsFromViper(parameters.WithParseStepSource("viper")),
 		),

--- a/pkg/cmds/layers/helpers.go
+++ b/pkg/cmds/layers/helpers.go
@@ -11,6 +11,7 @@ type ESHelperSettings struct {
 	PrintQuery bool   `glazed.parameter:"print-query"`
 	Explain    bool   `glazed.parameter:"explain"`
 	Index      string `glazed.parameter:"es-index"`
+	RawResults bool   `glazed.parameter:"raw-results"`
 }
 
 func NewESHelpersParameterLayer(
@@ -33,6 +34,12 @@ func NewESHelpersParameterLayer(
 			"es-index",
 			parameters.ParameterTypeString,
 			parameters.WithHelp("The index to search in"),
+		),
+		parameters.NewParameterDefinition(
+			"raw-results",
+			parameters.ParameterTypeBool,
+			parameters.WithHelp("Whether to return raw results"),
+			parameters.WithDefault(false),
 		),
 	))
 	ret, err := layers.NewParameterLayer(ESHelpersSlug, "ES Helpers", options_...)

--- a/pkg/cmds/loader.go
+++ b/pkg/cmds/loader.go
@@ -132,7 +132,13 @@ func (escl *ElasticSearchCommandLoader) loadCommandsFromFile(
 		options_...,
 	)
 
-	esc, err := NewElasticSearchCommand(description, escl.clientFactory, "", escd.Query)
+	esc, err := NewElasticSearchCommand(
+		description,
+		escl.clientFactory,
+		"",
+		escd.Query,
+		escd.DefaultIndex,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +210,13 @@ func (escl *ElasticSearchCommandLoader) loadCommandsFromDir(
 		options_...,
 	)
 
-	esc, err := NewElasticSearchCommand(description, escl.clientFactory, queryTemplate, nil)
+	esc, err := NewElasticSearchCommand(
+		description,
+		escl.clientFactory,
+		queryTemplate,
+		escd.Query,
+		escd.DefaultIndex,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/error.go
+++ b/pkg/helpers/error.go
@@ -1,1 +1,0 @@
-package helpers


### PR DESCRIPTION
Adds two new features to improve Elasticsearch query handling:

Default Index Configuration:
- Add `default-index` field in command YAML configuration
- Use default index if no explicit index is provided via command line
- Return error if no index is specified through any method

Raw Results Output:
- Add new `--raw-results` flag to output unprocessed Elasticsearch responses
- Raw results are output as a single row with `raw_results` field containing 
  the complete JSON response