### PR TITLE
Add RunRawQuery helper for direct Elasticsearch query execution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,6 +68,20 @@
             ]
         },
         {
+            "name": "Escuse-me Serve",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/escuse-me",
+            "args": [
+                "serve",
+                "--log-level",
+                "debug"
+            ],
+            "envFile": "${workspaceFolder}/.envrc",
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "Run Command",
             "type": "go",
             "request": "launch",
@@ -81,7 +95,7 @@
             ],
             "envFile": "${workspaceFolder}/.envrc",
             "cwd": "${workspaceFolder}"
-        }
+        },
         {
             "name": "Search Summaries Embeddings (Alt)",
             "type": "go",

--- a/cmd/escuse-me/cmds/serve.go
+++ b/cmd/escuse-me/cmds/serve.go
@@ -259,6 +259,7 @@ func (s *ServeCommand) Run(
 					esClientLayer.Layer.GetSlug(),
 					esClientLayer.Parameters.ToMap(),
 				),
+				config.WithWhitelistLayers(layers.DefaultSlug),
 			),
 			generic_command.WithDefaultTemplateName("data-tables.tmpl.html"),
 			generic_command.WithDefaultIndexTemplateName(""),

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.23.3
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.17.0
 	github.com/go-go-golems/clay v0.1.32
-	github.com/go-go-golems/geppetto v0.4.39
-	github.com/go-go-golems/glazed v0.5.35
+	github.com/go-go-golems/geppetto v0.4.40
+	github.com/go-go-golems/glazed v0.5.36
 	github.com/go-go-golems/go-emrichen v0.0.4
 	github.com/go-go-golems/parka v0.5.20
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-go-golems/clay v0.1.32 h1:UoE1HiTMx54zjEjl9UpWwtDeaOHi4GJc7ETJKGIkkB8=
 github.com/go-go-golems/clay v0.1.32/go.mod h1:GbMmN/SGYHg5joiyp+7LdXp0oafbZpsQeXPSvkRGngI=
-github.com/go-go-golems/geppetto v0.4.39 h1:jzR97Zxif8vlaQj8BZbLSYcHLBgaEPBk28w30uup2sU=
-github.com/go-go-golems/geppetto v0.4.39/go.mod h1:zhXxy6CFlqx2DesejwqdIGx5RK+B0KbL+/hfQYSPRMs=
-github.com/go-go-golems/glazed v0.5.35 h1:LV0IWynl5ZpKxqNcf2UxrccfEScy4G7eEDez4J8fgpE=
-github.com/go-go-golems/glazed v0.5.35/go.mod h1:cySRZANlIpuZNBTYkofLe8ls7M6O/aur4spck3J7O7w=
+github.com/go-go-golems/geppetto v0.4.40 h1:e5K6nyN0NY3v5j2M0sdFJxleXaXHi/Dxidjsh0N/GoA=
+github.com/go-go-golems/geppetto v0.4.40/go.mod h1:fawPO6WgBIiGmyPmBCjeajgeFDWANg6taHp6EotXC8g=
+github.com/go-go-golems/glazed v0.5.36 h1:Wg4RvZtGNm5bcsIjTmH8zZG0mXNH219BHnkYFiaiA0g=
+github.com/go-go-golems/glazed v0.5.36/go.mod h1:cySRZANlIpuZNBTYkofLe8ls7M6O/aur4spck3J7O7w=
 github.com/go-go-golems/go-emrichen v0.0.4 h1:U8AKGaxBDjMghiZZe/7sRYiw3UPqRkkbAAc/d2Q9rK4=
 github.com/go-go-golems/go-emrichen v0.0.4/go.mod h1:yYf0DLUYLLZdvCODdpIBYUxgNz0ZomJFlGhhzlg+fs0=
 github.com/go-go-golems/parka v0.5.20 h1:y5cdyhilXbRI09D148lzAzEtIzlinRgDpdV5FKjpOjI=


### PR DESCRIPTION
This PR refactors the Elasticsearch query execution logic and adds a new 
helper method for executing raw queries:

* Extract common query execution logic into `executeQuery` helper method
* Add new `RunRawQuery` function that returns raw Elasticsearch results as 
  a map[string]interface{} instead of processing through Glaze
* Add DefaultSlug to whitelist layers in serve command

The new `RunRawQuery` function allows for direct execution of Elasticsearch 
queries without the overhead of Glaze processing, which is useful for 
programmatic access to Elasticsearch data.