### PR TITLE
Pass embeddings factory to commands instead of parsing layers in command body

### DIFF
--- a/cmd/escuse-me/main.go
+++ b/cmd/escuse-me/main.go
@@ -43,7 +43,7 @@ func main() {
 	if len(os.Args) >= 3 && os.Args[1] == "run-command" && os.Args[2] != "--help" {
 		// load the command
 		clientFactory := layers.NewSearchClientFromParsedLayers
-		loader := es_cmds.NewElasticSearchCommandLoader(clientFactory)
+		loader := es_cmds.NewElasticSearchCommandLoader(clientFactory, nil)
 
 		fs_, filePath, err := loaders.FileNameToFsFilePath(os.Args[2])
 		if err != nil {
@@ -138,7 +138,7 @@ func initAllCommands(helpSystem *help.HelpSystem) error {
 	repositoryPaths = append(repositoryPaths, defaultDirectory)
 
 	clientFactory := layers.NewSearchClientFromParsedLayers
-	loader := es_cmds.NewElasticSearchCommandLoader(clientFactory)
+	loader := es_cmds.NewElasticSearchCommandLoader(clientFactory, nil)
 
 	directories := []repositories.Directory{
 		{

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.23.3
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.17.0
 	github.com/go-go-golems/clay v0.1.32
-	github.com/go-go-golems/geppetto v0.4.40
-	github.com/go-go-golems/glazed v0.5.36
+	github.com/go-go-golems/geppetto v0.4.41
+	github.com/go-go-golems/glazed v0.5.37
 	github.com/go-go-golems/go-emrichen v0.0.4
 	github.com/go-go-golems/parka v0.5.20
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-go-golems/clay v0.1.32 h1:UoE1HiTMx54zjEjl9UpWwtDeaOHi4GJc7ETJKGIkkB8=
 github.com/go-go-golems/clay v0.1.32/go.mod h1:GbMmN/SGYHg5joiyp+7LdXp0oafbZpsQeXPSvkRGngI=
-github.com/go-go-golems/geppetto v0.4.40 h1:e5K6nyN0NY3v5j2M0sdFJxleXaXHi/Dxidjsh0N/GoA=
-github.com/go-go-golems/geppetto v0.4.40/go.mod h1:fawPO6WgBIiGmyPmBCjeajgeFDWANg6taHp6EotXC8g=
-github.com/go-go-golems/glazed v0.5.36 h1:Wg4RvZtGNm5bcsIjTmH8zZG0mXNH219BHnkYFiaiA0g=
-github.com/go-go-golems/glazed v0.5.36/go.mod h1:cySRZANlIpuZNBTYkofLe8ls7M6O/aur4spck3J7O7w=
+github.com/go-go-golems/geppetto v0.4.41 h1:iXZ35O47vR3D8sg2jlq/6lfZbXz3qZuKL+ljgrcjKA4=
+github.com/go-go-golems/geppetto v0.4.41/go.mod h1:fawPO6WgBIiGmyPmBCjeajgeFDWANg6taHp6EotXC8g=
+github.com/go-go-golems/glazed v0.5.37 h1:pb+0dJ1IYU9guf5zas4RaaOtE16H3NPFm1mmY0rnuVs=
+github.com/go-go-golems/glazed v0.5.37/go.mod h1:cySRZANlIpuZNBTYkofLe8ls7M6O/aur4spck3J7O7w=
 github.com/go-go-golems/go-emrichen v0.0.4 h1:U8AKGaxBDjMghiZZe/7sRYiw3UPqRkkbAAc/d2Q9rK4=
 github.com/go-go-golems/go-emrichen v0.0.4/go.mod h1:yYf0DLUYLLZdvCODdpIBYUxgNz0ZomJFlGhhzlg+fs0=
 github.com/go-go-golems/parka v0.5.20 h1:y5cdyhilXbRI09D148lzAzEtIzlinRgDpdV5FKjpOjI=

--- a/pkg/cmds/factory.go
+++ b/pkg/cmds/factory.go
@@ -2,11 +2,12 @@ package cmds
 
 import (
 	"github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/geppetto/pkg/embeddings"
 	"github.com/go-go-golems/parka/pkg/handlers"
 )
 
 func NewRepositoryFactory() handlers.RepositoryFactory {
-	loader := NewElasticSearchCommandLoader(layers.NewSearchClientFromParsedLayers)
+	loader := NewElasticSearchCommandLoader(layers.NewSearchClientFromParsedLayers, embeddings.NewSettingsFactoryFromParsedLayers)
 
 	return handlers.NewRepositoryFactoryFromReaderLoaders(loader)
 }

--- a/pkg/cmds/loader.go
+++ b/pkg/cmds/loader.go
@@ -28,7 +28,8 @@ import (
 //   - this data is passed to the template at evaluation file,
 //     and can be used to store things like tags and constant strings, boost values and the like
 type ElasticSearchCommandLoader struct {
-	clientFactory SearchClientFactory
+	clientFactory     SearchClientFactory
+	embeddingsFactory EmbeddingsFactory
 }
 
 type RawNode struct {
@@ -44,9 +45,11 @@ var _ loaders.CommandLoader = (*ElasticSearchCommandLoader)(nil)
 
 func NewElasticSearchCommandLoader(
 	clientFactory SearchClientFactory,
+	embeddingsFactory EmbeddingsFactory,
 ) *ElasticSearchCommandLoader {
 	return &ElasticSearchCommandLoader{
-		clientFactory: clientFactory,
+		clientFactory:     clientFactory,
+		embeddingsFactory: embeddingsFactory,
 	}
 }
 
@@ -141,6 +144,7 @@ func (escl *ElasticSearchCommandLoader) loadCommandsFromFile(
 	esc, err := NewElasticSearchCommand(
 		description,
 		escl.clientFactory,
+		escl.embeddingsFactory,
 		"",
 		escd.Query,
 		escd.DefaultIndex,
@@ -219,6 +223,7 @@ func (escl *ElasticSearchCommandLoader) loadCommandsFromDir(
 	esc, err := NewElasticSearchCommand(
 		description,
 		escl.clientFactory,
+		escl.embeddingsFactory,
 		queryTemplate,
 		escd.Query,
 		escd.DefaultIndex,

--- a/ttmp/2025-03-07/01-add-opensearch-go.md
+++ b/ttmp/2025-03-07/01-add-opensearch-go.md
@@ -1,0 +1,249 @@
+# Migrating a Golang Application from Elasticsearch to OpenSearch: A Comprehensive Guide  
+
+This report provides an in-depth technical roadmap for transitioning a Golang application from Elasticsearch to OpenSearch, covering client library migration strategies, compatibility considerations, code adaptation patterns, and operational best practices. The analysis draws on official OpenSearch documentation[1][3][8], migration guides[4][5], and real-world implementation examples[6][7] to create a structured migration framework.  
+
+## Client Architecture and Compatibility Analysis  
+
+OpenSearch maintains API compatibility with Elasticsearch 7.10.2 while introducing enhanced security features and open-source governance[4][5]. The migration process requires understanding three critical compatibility layers:  
+
+1. **Protocol Compatibility**: OpenSearch preserves the Elasticsearch REST API structure, ensuring existing _search, index, and cluster management_ endpoints function identically when using compatible client versions[1][4]. This enables partial migration strategies where applications can temporarily interact with both systems during transition phases.  
+
+2. **Client Library Divergence**: While the OpenSearch Go client (`github.com/opensearch-project/opensearch-go/v4`) shares architectural similarities with Elastic's official client, implementation differences exist in authentication handling, connection pooling, and error response parsing[3][8]. Applications using third-party Elasticsearch libraries like `olivere/elastic` require significant code restructuring due to diverging query builder APIs[7].  
+
+3. **Security Model Alignment**: OpenSearch's default security plugin implementation differs from Elastic's X-Pack, requiring TLS configuration and credential management adjustments even in basic setups[1][6]. The migration must account for these security paradigm shifts through modified client initialization:  
+
+```go
+// OpenSearch secure client initialization
+client, err := opensearch.NewClient(opensearch.Config{
+  Addresses: []string{"https://opensearch.example.com:9200"},
+  Username:  "admin", 
+  Password:  "admin",
+  Transport: &http.Transport{
+    TLSClientConfig: &tls.Config{
+      InsecureSkipVerify: true, // Remove for production
+      MinVersion:         tls.VersionTLS12,
+    },
+  },
+})
+```
+This contrasts with Elasticsearch's less restrictive default security posture, necessitating careful TLS configuration during migration[1][6].  
+
+## Step-by-Step Migration Process  
+
+### Phase 1: Dependency and Configuration Migration  
+
+Begin by replacing Elasticsearch client dependencies in `go.mod`:  
+
+```bash
+# Remove Elasticsearch client
+go get -u github.com/elastic/go-elasticsearch/v8@none
+
+# Install OpenSearch client  
+go get github.com/opensearch-project/opensearch-go/v4@latest
+```
+
+Update client initialization code to use OpenSearch's enhanced configuration structure[1][3]:  
+
+```go
+import (
+  "github.com/opensearch-project/opensearch-go/v4"
+  "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+func NewOSClient() (*opensearch.Client, error) {
+  return opensearch.NewClient(opensearch.Config{
+    Addresses: []string{"http://localhost:9200"},
+    Transport: &http.Transport{
+      ResponseHeaderTimeout: 30 * time.Second,
+      TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+    },
+  })
+}
+```
+Key differences from Elasticsearch client initialization include mandatory TLS configuration and explicit transport timeouts[1][3].  
+
+### Phase 2: Query and Index Operation Adaptation  
+
+While basic CRUD operations maintain API similarity, complex queries require structural adjustments:  
+
+**Elasticsearch (NEST-style query):**  
+```go
+elastic.NewBoolQuery().
+  Must(elastic.NewTermQuery("status", "published")).
+  Filter(elastic.NewRangeQuery("date").Gt("2022-01-01"))
+```
+
+**OpenSearch Equivalent:**  
+```go
+map[string]interface{}{
+  "query": map[string]interface{}{
+    "bool": map[string]interface{}{
+      "must": map[string]interface{}{
+        "term": map[string]interface{}{"status": "published"},
+      },
+      "filter": map[string]interface{}{
+        "range": map[string]interface{}{
+          "date": map[string]interface{}{"gt": "2022-01-01"},
+        },
+      },
+    },
+  },
+}
+```
+Applications must transition from fluent query builders to native map-based constructions due to OpenSearch's current lack of high-level query DSL[7][8]. For complex query scenarios, consider implementing a translation layer or adopting third-party query builders compatible with OpenSearch's API surface.  
+
+### Phase 3: Index Management and Cluster Operations  
+
+Reimplement Elasticsearch-specific index operations using OpenSearch's enhanced API endpoints:  
+
+```go
+// Create index with explicit settings
+req := opensearchapi.IndicesCreateRequest{
+  Index: "logs-2023",
+  Body: strings.NewReader(`{
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 2,
+      "opensearch": {
+        "store_type": "remote_snapshot"
+      }
+    }
+  }`),
+}
+
+res, err := req.Do(context.Background(), client)
+```
+Key differences include OpenSearch-specific settings like `remote_snapshot` storage types and enhanced security parameters in index templates[1][6].  
+
+## Advanced Migration Considerations  
+
+### AWS OpenSearch Service Integration  
+
+When migrating to AWS-managed OpenSearch, implement AWS Signature V4 request signing:  
+
+```go
+cfg, _ := config.LoadDefaultConfig(context.TODO())
+signer := requestsigner.NewSignerWithService(cfg, "es")
+
+client, _ := opensearch.NewClient(opensearch.Config{
+  Addresses: []string{"https://search-mydomain.us-east-1.es.amazonaws.com"},
+  Signer:    signer,
+})
+```
+This AWS-specific authentication layer replaces basic auth credentials used in self-managed deployments[1][6].  
+
+### Bulk Operation Optimization  
+
+Adapt bulk indexing workflows to leverage OpenSearch's enhanced bulk API:  
+
+```go
+var buf bytes.Buffer
+for _, doc := range documents {
+  meta := map[string]interface{}{
+    "index": map[string]interface{}{
+      "_index": "logs",
+      "_id":    doc.ID,
+    },
+  }
+  buf.WriteString(fmt.Sprintf("%s\n", meta))
+  buf.WriteString(fmt.Sprintf("%s\n", doc.Content))
+}
+
+res, err := client.Bulk(
+  strings.NewReader(buf.String()),
+  client.Bulk.WithRefresh("wait_for"),
+)
+```
+Key performance considerations include batch size optimization (recommended 5-15MB per batch) and proper error handling for partial failures[6][8].  
+
+## Migration Validation Strategy  
+
+Implement a three-phase validation process:  
+
+1. **Functional Equivalence Testing**  
+   - Replay production queries against both clusters  
+   - Compare result sets using checksum validation  
+   - Benchmark latency percentiles across both systems  
+
+2. **Data Consistency Verification**  
+```go
+// Cross-cluster document count verification
+esCount := elasticClient.Count().Index("logs").Do()
+osCount := openSearchClient.Count().Index("logs").Do()
+
+if esCount != osCount {
+  log.Fatal("Document count mismatch between clusters")
+}
+```
+
+3. **Production Traffic Shadowing**  
+   - Mirror write operations to both clusters  
+   - Compare indexing performance metrics  
+   - Validate search result parity using automated sampling  
+
+## Operational Considerations  
+
+### Monitoring and Alerting  
+
+Adapt Elasticsearch-specific monitoring checks to OpenSearch metrics:  
+
+- Replace `elasticsearch_cluster_status` with `opensearch_cluster_health`  
+- Update disk space alerts for OpenSearch's segment management  
+- Implement security audit logging for RBAC changes  
+
+### CI/CD Pipeline Adjustments  
+
+Update infrastructure-as-code templates:  
+
+```terraform
+resource "aws_opensearch_domain" "logs" {
+  domain_name    = "application-logs"
+  engine_version = "OpenSearch_2.5"
+
+  cluster_config {
+    instance_type  = "r6g.large.search"
+    instance_count = 3
+  }
+}
+```
+Key changes include OpenSearch-specific versioning and AWS resource types[4][6].  
+
+## Conclusion  
+
+Migrating from Elasticsearch to OpenSearch in Golang applications requires careful consideration of client library differences, security model updates, and query API adaptations. By following this structured approach—encompassing dependency management, code migration, validation strategies, and operational adjustments—teams can achieve a smooth transition while leveraging OpenSearch's enhanced features. Future-proof the implementation by monitoring OpenSearch client updates and participating in the open-source community to address emerging compatibility requirements[3][5][8].
+
+Citations:
+[1] https://opensearch.org/docs/latest/clients/go/
+[2] https://www.reddit.com/r/golang/comments/vxy4ay/go_with_elastic_search/
+[3] https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v4
+[4] https://sematext.com/blog/migration-from-elasticsearch-to-opensearch/
+[5] https://dev.to/laysauchoa/how-to-migrate-your-elasticsearch-client-to-using-opensearch-502p
+[6] https://dev.to/ankitmalikg/opensearch-crud-operation-in-go-3f0j
+[7] https://forum.opensearch.org/t/opensearch-querybuilder-in-golang/10367
+[8] https://pkg.go.dev/github.com/opensearch-project/opensearch-go
+[9] https://community.temporal.io/t/add-support-for-aws-elasticsearch-request-signing/213
+[10] https://1291fa08092a4a2dfd6d43f11d7bbcf3f22bf569.opensearch.org/docs/1.0/clients/go/
+[11] https://aiven.io/blog/migrate-elasticsearch-client-to-opensearch
+[12] https://www.reddit.com/r/devops/comments/1hfmzdu/migrating_from_elasticsearch_to_opensearch/
+[13] https://community.aws/content/2fBVnCWwN5TEa1wEWl5Wah7Vb2A/migrating-golang-project-using-elasticsearch-to-opensearch-with-amazonq?lang=en
+[14] https://www.elastic.co/observability-labs/blog/migrating-billion-log-lines-opensearch-elasticsearch
+[15] https://pkg.go.dev/github.com/opensearch-project/opensearch-go/v2
+[16] https://stackoverflow.com/questions/68802324/elasticsearch-in-go-err-the-client-noticed-that-the-server-is-not-elasticsear
+[17] https://pkg.go.dev/github.com/opensearch-project/opensearch-go/opensearchapi
+[18] https://forum.opensearch.org/t/golang-client-libraries-olivere-elastic-elastic-go-elasticsearch/5174
+[19] https://github.com/opensearch-project/opensearch-go/blob/main/USER_GUIDE.md
+[20] https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/
+[21] https://docs.aws.amazon.com/opensearch-service/latest/developerguide/custom-packages.html
+[22] https://github.com/elastic/go-elasticsearch
+[23] https://forum.opensearch.org/t/building-a-crud-with-opensearch-and-golang/18755
+[24] https://www.elastic.co/amazon-opensearch-service
+[25] https://docs.aws.amazon.com/sdk-for-go/api/service/opensearchservice/
+[26] https://github.com/golang-migrate/migrate/pull/1175
+[27] https://forum.opensearch.org/t/migrating-from-elasticsearch-7-16-1-to-opensearch/18035
+[28] https://github.com/opensearch-project/opensearch-go
+[29] https://github.com/opensearch-project/opensearch-migrations
+[30] https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/opensearch
+[31] https://forum.opensearch.org/t/migrate-elasticsearch-5-x-to-opensearch-1-0/8406
+[32] https://aws.amazon.com/blogs/big-data/accelerate-your-migration-to-amazon-opensearch-service-with-reindexing-from-snapshot/
+[33] https://pkg.go.dev/github.com/opensearch-project/opensearch-go/opensearchutil
+[34] https://www.youtube.com/watch?v=0b8sUJK9fqY

--- a/ttmp/2025-03-07/02-migration-plan.md
+++ b/ttmp/2025-03-07/02-migration-plan.md
@@ -1,0 +1,94 @@
+<think>
+Based on the request, I need to create a plan to add support for OpenSearch to the existing Elasticsearch client. Let me analyze the current structure and understand what needs to be modified:
+
+1. The project appears to be using Elasticsearch client libraries.
+2. We need to add support for OpenSearch while maintaining compatibility with Elasticsearch.
+3. The changes will affect multiple parts of the codebase, including client initialization and command execution.
+
+From the provided file contents, I see:
+- `pkg/cmds/layers/settings.go` contains ES client settings and initialization code
+- `cmd/escuse-me/cmds/indices/ls.go` contains a command to list indices
+- The detailed migration guide in `ttmp/2025-03-07/01-add-opensearch-go.md`
+
+Let me outline a plan for implementing OpenSearch support:
+</think>
+
+# Implementation Plan: Adding OpenSearch Support
+
+## Progress Update
+
+### Completed Steps:
+- [x] Added OpenSearch Go client dependency (`github.com/opensearch-project/opensearch-go/v4`)
+- [x] Added client type selection to es.yaml configuration
+- [x] Created SearchClient interface for abstracting both clients
+- [x] Implemented client wrappers for both Elasticsearch and OpenSearch
+- [x] Updated ls command to use the new interface
+- [x] Implemented ListIndices for both client types
+
+### OpenSearch API Implementation Notes
+After investigating the OpenSearch API, we found that:
+
+1. The OpenSearch Go client provides a lower-level API compared to Elasticsearch:
+   - Uses raw HTTP requests with `Client.Perform()`
+   - Requires manual URL and query parameter construction
+   - No high-level abstractions like `Cat.Indices()` as in Elasticsearch
+
+2. API Compatibility:
+   - OpenSearch maintains API endpoint compatibility with Elasticsearch
+   - Same endpoints (e.g., `/_cat/indices`) work for both systems
+   - Query parameters and response formats are consistent
+
+3. Implementation Strategy:
+   ```go
+   // OpenSearch implementation
+   func (c *OpenSearchClient) ListIndices(ctx context.Context) ([]byte, error) {
+       req := &http.Request{
+           Method: "GET",
+           URL: &url.URL{
+               Path: "/_cat/indices",
+               RawQuery: "format=json&h=health,status,index,...",
+           },
+       }
+       resp, err := c.Client.Perform(req)
+       // ... handle response
+   }
+
+   // vs Elasticsearch implementation
+   func (c *ElasticsearchClient) ListIndices(ctx context.Context) ([]byte, error) {
+       res, err := c.Cat.Indices(c.Cat.Indices.WithFormat("json"))
+       // ... handle response
+   }
+   ```
+
+### Next Steps:
+1. Testing & Validation for ls command
+   - [ ] Test with Elasticsearch instance
+   - [ ] Test with OpenSearch instance
+   - [ ] Verify output format consistency
+
+2. Future Command Adaptations
+   - [ ] Create helper functions for common OpenSearch API operations
+   - [ ] Document OpenSearch API usage patterns
+   - [ ] Update other indices commands with similar patterns
+
+## Testing Strategy
+1. Manual Testing
+   - Test with Elasticsearch 7.x/8.x
+   - Test with OpenSearch 1.x/2.x
+   - Verify output format consistency
+
+2. Integration Tests (TODO)
+   - Add test cases for both client types
+   - Test error handling
+   - Test configuration parsing
+
+## Notes
+- OpenSearch client requires manual request construction
+- Most API endpoints are compatible between both systems
+- Consider creating helper functions for common OpenSearch operations
+
+## Next Steps
+1. Add tests for the ls command implementation
+2. Document the client type selection in README
+3. Create helper functions for OpenSearch API operations
+4. Plan migration of other commands


### PR DESCRIPTION
This PR refactors how embeddings are handled in ElasticSearchCommand by:

* Adding a dedicated EmbeddingsFactory type similar to SearchClientFactory
* Passing the factory during command creation rather than recreating it during 
  execution
* Making embeddings optional with appropriate nil checks
* Updating all command loader instances to accept the new factory parameter
* Setting up the repository factory to use the standard embeddings factory