### PR TITLE
Add comprehensive Elasticsearch alias management commands

### DIFF
--- a/cmd/escuse-me/cmds/indices/alias.go
+++ b/cmd/escuse-me/cmds/indices/alias.go
@@ -1,0 +1,294 @@
+package indices
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	layers2 "github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+type IndicesGetAliasCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.GlazeCommand = &IndicesGetAliasCommand{}
+
+// NewIndicesGetAliasCommand creates a new command for fetching index aliases.
+func NewIndicesGetAliasCommand() (*IndicesGetAliasCommand, error) {
+	glazedParameterLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+
+	esParameterLayer, err := layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	return &IndicesGetAliasCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"aliases", // Changed command name to plural for consistency
+			cmds.WithShort("Prints indices aliases"),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"index",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("A list of index names to filter aliases"),
+					parameters.WithDefault([]string{}), // Default to empty, meaning all indices if name is also empty
+				),
+				parameters.NewParameterDefinition(
+					"name",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("A list of alias names to return"),
+					parameters.WithDefault([]string{}), // Default to empty, meaning all aliases if index is also empty
+				),
+				parameters.NewParameterDefinition(
+					"allow_no_indices",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Whether to ignore if a wildcard expression matches no indices"),
+					parameters.WithDefault(true),
+				),
+				parameters.NewParameterDefinition(
+					"expand_wildcards",
+					parameters.ParameterTypeChoiceList,
+					parameters.WithHelp("Whether to expand wildcard expression to concrete indices that are open, closed or both"),
+					parameters.WithDefault([]string{"open"}), // Default typically 'open' for aliases
+					parameters.WithChoices("open", "closed", "none", "all"),
+				),
+				parameters.NewParameterDefinition(
+					"ignore_unavailable",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Whether specified concrete indices should be ignored when unavailable (missing or closed)"),
+					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"local",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Return local information, do not retrieve the state from master node (default: false)"),
+					parameters.WithDefault(false),
+				),
+			),
+			cmds.WithLayersList(
+				glazedParameterLayer,
+				esParameterLayer,
+			),
+		),
+	}, nil
+}
+
+// IndicesGetAliasSettings holds the settings for the alias command.
+type IndicesGetAliasSettings struct {
+	Indices           []string `glazed.parameter:"index"`
+	Name              []string `glazed.parameter:"name"`
+	AllowNoIndices    bool     `glazed.parameter:"allow_no_indices"`
+	IgnoreUnavailable bool     `glazed.parameter:"ignore_unavailable"`
+	ExpandWildcards   []string `glazed.parameter:"expand_wildcards"`
+	Local             bool     `glazed.parameter:"local"`
+}
+
+// AliasInfo holds the details of a single alias. We use interface{} for flexibility.
+type AliasInfo = *orderedmap.OrderedMap[string, interface{}]
+
+// IndexAliases holds the aliases associated with a specific index.
+type IndexAliases struct {
+	Aliases *orderedmap.OrderedMap[string, AliasInfo] `json:"aliases"`
+}
+
+// AliasResponse maps index names to their alias information.
+type AliasResponse = *orderedmap.OrderedMap[string, IndexAliases]
+
+// RunIntoGlazeProcessor executes the alias command and outputs results to the Glaze processor.
+func (i *IndicesGetAliasCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *layers2.ParsedLayers,
+	gp middlewares.Processor,
+) error {
+	s := &IndicesGetAliasSettings{}
+	err := parsedLayers.InitializeStruct(layers2.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize settings struct")
+	}
+
+	es, err := layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	// Prepare options for the API call
+	options := []func(*esapi.IndicesGetAliasRequest){}
+	if len(s.Indices) > 0 {
+		options = append(options, es.Indices.GetAlias.WithIndex(s.Indices...))
+	}
+	if len(s.Name) > 0 {
+		options = append(options, es.Indices.GetAlias.WithName(s.Name...))
+	}
+	options = append(options,
+		es.Indices.GetAlias.WithAllowNoIndices(s.AllowNoIndices),
+		es.Indices.GetAlias.WithIgnoreUnavailable(s.IgnoreUnavailable),
+		es.Indices.GetAlias.WithExpandWildcards(strings.Join(s.ExpandWildcards, ",")),
+		es.Indices.GetAlias.WithLocal(s.Local),
+	)
+
+	log.Debug().
+		Strs("indices", s.Indices).
+		Strs("names", s.Name).
+		Bool("allowNoIndices", s.AllowNoIndices).
+		Bool("ignoreUnavailable", s.IgnoreUnavailable).
+		Strs("expandWildcards", s.ExpandWildcards).
+		Bool("local", s.Local).
+		Msg("Retrieving aliases")
+
+	res, err := es.Indices.GetAlias(options...)
+	if err != nil {
+		return errors.Wrap(err, "failed to get aliases")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	if res.IsError() {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("elasticsearch error: [%d] %s", res.StatusCode, string(bodyBytes))
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
+
+	// Check for explicit ES error response within the JSON body
+	var errorResponse struct {
+		Error struct {
+			Type   string `json:"type"`
+			Reason string `json:"reason"`
+		} `json:"error"`
+		Status int `json:"status"`
+	}
+	// Try unmarshalling into error struct first
+	_ = json.Unmarshal(body, &errorResponse) // Ignore error, as it might not be an error response
+	if errorResponse.Status != 0 || errorResponse.Error.Type != "" {
+		log.Error().
+			Str("errorType", errorResponse.Error.Type).
+			Str("reason", errorResponse.Error.Reason).
+			Int("status", errorResponse.Status).
+			Msg("Elasticsearch returned an error in the response body")
+		// Consider returning a more specific error based on the response
+		return fmt.Errorf("elasticsearch error response: Status %d, Type: %s, Reason: %s",
+			errorResponse.Status, errorResponse.Error.Type, errorResponse.Error.Reason)
+	}
+
+	aliasResponse := orderedmap.New[string, IndexAliases]()
+	// Use json.NewDecoder for potentially better handling of large responses / streaming
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	err = decoder.Decode(&aliasResponse)
+
+	// Specific check for empty response or non-map structure if expected
+	if err != nil && aliasResponse.Len() == 0 {
+		// Check if the body was empty or just not a valid JSON map structure expected
+		if len(strings.TrimSpace(string(body))) == 0 {
+			log.Info().Msg("Received empty response from Elasticsearch for aliases.")
+			// Potentially return nil if an empty response is acceptable (e.g., no matching aliases found)
+			return nil
+		}
+		if strings.TrimSpace(string(body)) == "{}" {
+			log.Info().Msg("Received empty map {} response from Elasticsearch for aliases.")
+			return nil
+		}
+		log.Error().Err(err).Str("body", string(body)).Msg("Failed to unmarshal alias response")
+		return errors.Wrapf(err, "failed to unmarshal alias response body: %s", string(body))
+	}
+	if err != nil {
+		// If decoding failed for other reasons
+		log.Error().Err(err).Str("body", string(body)).Msg("Failed to unmarshal alias response")
+		return errors.Wrapf(err, "failed to unmarshal alias response body: %s", string(body))
+	}
+
+	rows := []types.Row{}
+
+	for pair := aliasResponse.Oldest(); pair != nil; pair = pair.Next() {
+		indexName := pair.Key
+		indexData := pair.Value
+
+		if indexData.Aliases == nil || indexData.Aliases.Len() == 0 {
+			// Optionally represent indices with no matching aliases if needed
+			// row := types.NewRow(
+			// 	types.MRP("index", indexName),
+			// 	types.MRP("alias", types.Nil), // Or ""
+			// )
+			// rows = append(rows, row)
+			continue // Skip indices with no aliases in this output format
+		}
+
+		for aliasPair := indexData.Aliases.Oldest(); aliasPair != nil; aliasPair = aliasPair.Next() {
+			aliasName := aliasPair.Key
+			aliasDetails := aliasPair.Value // This is an orderedmap.OrderedMap[string, interface{}]
+
+			// Create a base row with index and alias name
+			rowMap := map[string]interface{}{
+				"index": indexName,
+				"alias": aliasName,
+			}
+
+			// Add alias properties dynamically
+			if aliasDetails != nil {
+				for detailPair := aliasDetails.Oldest(); detailPair != nil; detailPair = detailPair.Next() {
+					// Prefix alias properties to avoid clashes, e.g., 'alias_filter', 'alias_is_write_index'
+					key := "alias_" + detailPair.Key
+					value := detailPair.Value
+
+					// Attempt to marshal complex values (like filters) to JSON strings for readability
+					if mapVal, ok := value.(map[string]interface{}); ok {
+						jsonVal, err := json.Marshal(mapVal)
+						if err == nil {
+							value = string(jsonVal)
+						}
+					} else if sliceVal, ok := value.([]interface{}); ok {
+						jsonVal, err := json.Marshal(sliceVal)
+						if err == nil {
+							value = string(jsonVal)
+						}
+					}
+					rowMap[key] = value
+				}
+			}
+
+			rows = append(rows, types.NewRowFromMap(rowMap))
+		}
+	}
+
+	// Sort rows primarily by index, then by alias name
+	sort.Slice(rows, func(i, j int) bool {
+		indexI, _ := rows[i].Get("index")
+		indexJ, _ := rows[j].Get("index")
+		if indexI.(string) != indexJ.(string) {
+			return indexI.(string) < indexJ.(string)
+		}
+		aliasI, _ := rows[i].Get("alias")
+		aliasJ, _ := rows[j].Get("alias")
+		return aliasI.(string) < aliasJ.(string)
+	})
+
+	for _, row := range rows {
+		err = gp.AddRow(ctx, row)
+		if err != nil {
+			return errors.Wrap(err, "failed to add row to processor")
+		}
+	}
+
+	log.Debug().Int("rowCount", len(rows)).Msg("Successfully processed aliases")
+	return nil
+}

--- a/cmd/escuse-me/cmds/indices/create-alias.go
+++ b/cmd/escuse-me/cmds/indices/create-alias.go
@@ -1,0 +1,176 @@
+package indices
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	glazed_layers "github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type IndicesCreateAliasCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.BareCommand = &IndicesCreateAliasCommand{}
+
+func NewIndicesCreateAliasCommand() (*IndicesCreateAliasCommand, error) {
+	glazedLayer, err := settings.NewGlazedParameterLayers(
+		// Action commands often don't need complex output formatting
+		settings.WithOutputParameterLayerOptions(
+			glazed_layers.WithDefaults(map[string]interface{}{
+				"output": "yaml",
+			}),
+		),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+
+	esLayer, err := es_layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	return &IndicesCreateAliasCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"create-alias",
+			cmds.WithShort("Creates or updates an index alias"),
+			cmds.WithLong(`Adds an alias to the specified index or indices. Supports setting filter, routing, and write index properties via a JSON body.`),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"index",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("Comma-separated list of index names the alias should point to"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"name",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("The name of the alias to be created or updated"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"body",
+					parameters.ParameterTypeObjectFromFile, // Allows reading JSON/YAML from file or stdin
+					parameters.WithHelp("JSON/YAML object defining alias properties (filter, routing, is_write_index)"),
+					parameters.WithRequired(false), // Optional if no extra properties needed
+				),
+				parameters.NewParameterDefinition(
+					"master_timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Specify timeout in seconds for connection to master node"),
+					parameters.WithDefault(30),
+				),
+				parameters.NewParameterDefinition(
+					"timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Explicit operation timeout in seconds"),
+					parameters.WithDefault(30),
+				),
+			),
+			cmds.WithLayersList(glazedLayer, esLayer),
+		),
+	}, nil
+}
+
+type IndicesCreateAliasSettings struct {
+	Index         []string               `glazed.parameter:"index"`
+	Name          string                 `glazed.parameter:"name"`
+	Body          map[string]interface{} `glazed.parameter:"body"`
+	MasterTimeout time.Duration          `glazed.parameter:"master_timeout"`
+	Timeout       time.Duration          `glazed.parameter:"timeout"`
+}
+
+func (c *IndicesCreateAliasCommand) Run(
+	ctx context.Context,
+	parsedLayers *glazed_layers.ParsedLayers,
+) error {
+	s := &IndicesCreateAliasSettings{}
+	err := parsedLayers.InitializeStruct(glazed_layers.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize settings struct")
+	}
+
+	es, err := es_layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	log.Debug().
+		Strs("indices", s.Index).
+		Str("name", s.Name).
+		Interface("body", s.Body).
+		Dur("master_timeout", s.MasterTimeout).
+		Dur("timeout", s.Timeout).
+		Msg("Creating/updating alias")
+
+	options := []func(*esapi.IndicesPutAliasRequest){
+		es.Indices.PutAlias.WithContext(ctx),
+		es.Indices.PutAlias.WithMasterTimeout(s.MasterTimeout),
+		es.Indices.PutAlias.WithTimeout(s.Timeout),
+	}
+
+	var requestBody io.Reader
+	if len(s.Body) > 0 {
+		bodyBytes, err := json.Marshal(s.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal request body")
+		}
+		requestBody = bytes.NewReader(bodyBytes)
+		options = append(options, es.Indices.PutAlias.WithBody(requestBody))
+		log.Debug().Str("body_json", string(bodyBytes)).Msg("Using request body")
+	} else {
+		log.Debug().Msg("No request body provided")
+	}
+
+	res, err := es.Indices.PutAlias(
+		s.Index,
+		s.Name,
+		options...,
+	)
+	if err != nil {
+		return errors.Wrap(err, "alias creation request failed")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read response body")
+		if res.IsError() {
+			return fmt.Errorf("elasticsearch create alias error: [%d] (failed to read full body: %v)", res.StatusCode, err)
+		}
+		return errors.Wrap(err, "failed to read response body")
+	}
+	bodyString := string(bodyBytes)
+
+	if res.IsError() {
+		log.Error().
+			Int("status_code", res.StatusCode).
+			Str("response", bodyString).
+			Msg("Elasticsearch error response")
+		return fmt.Errorf("elasticsearch create alias error: [%d] %s", res.StatusCode, bodyString)
+	}
+
+	log.Info().
+		Int("status_code", res.StatusCode).
+		Str("response", bodyString). // Log the successful response
+		Msg("Alias created/updated successfully")
+
+	// Print the raw JSON response to standard output
+	fmt.Println(bodyString)
+
+	return nil
+}

--- a/cmd/escuse-me/cmds/indices/delete-alias.go
+++ b/cmd/escuse-me/cmds/indices/delete-alias.go
@@ -1,0 +1,156 @@
+package indices
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	glazed_layers "github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type IndicesDeleteAliasCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.BareCommand = &IndicesDeleteAliasCommand{}
+
+// NewIndicesDeleteAliasCommand creates a new command for deleting index aliases.
+func NewIndicesDeleteAliasCommand() (*IndicesDeleteAliasCommand, error) {
+	glazedParameterLayer, err := settings.NewGlazedParameterLayers(
+		settings.WithOutputParameterLayerOptions(
+			glazed_layers.WithDefaults(map[string]interface{}{
+				"output": "yaml",
+			}),
+		),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+
+	esParameterLayer, err := layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	return &IndicesDeleteAliasCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"delete-alias",
+			cmds.WithShort("Deletes an index alias"),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"index",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("A list of index names the alias should be removed from"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"name",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("A list of aliases to delete"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"master_timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Specify timeout in seconds for connection to master node"),
+					parameters.WithDefault(30),
+				),
+				parameters.NewParameterDefinition(
+					"timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Explicit operation timeout in seconds"),
+					parameters.WithDefault(30),
+				),
+			),
+			cmds.WithLayersList(
+				glazedParameterLayer,
+				esParameterLayer,
+			),
+		),
+	}, nil
+}
+
+// IndicesDeleteAliasSettings holds the settings for the delete-alias command.
+type IndicesDeleteAliasSettings struct {
+	Indices           []string      `glazed.parameter:"index"`
+	Name              []string      `glazed.parameter:"name"`
+	MasterTimeoutSecs int           `glazed.parameter:"master_timeout"`
+	TimeoutSecs       int           `glazed.parameter:"timeout"`
+	MasterTimeout     time.Duration `glazed.ignore:"true"`
+	Timeout           time.Duration `glazed.ignore:"true"`
+}
+
+// Run executes the delete-alias command (BareCommand implementation).
+func (i *IndicesDeleteAliasCommand) Run(
+	ctx context.Context,
+	parsedLayers *glazed_layers.ParsedLayers,
+) error {
+	s := &IndicesDeleteAliasSettings{}
+	err := parsedLayers.InitializeStruct(glazed_layers.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize settings struct")
+	}
+
+	s.Timeout = time.Duration(s.TimeoutSecs) * time.Second
+	s.MasterTimeout = time.Duration(s.MasterTimeoutSecs) * time.Second
+
+	es, err := layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	log.Debug().
+		Strs("indices", s.Indices).
+		Strs("names", s.Name).
+		Dur("master_timeout", s.MasterTimeout).
+		Dur("timeout", s.Timeout).
+		Msg("Deleting aliases")
+
+	res, err := es.Indices.DeleteAlias(
+		s.Indices,
+		s.Name,
+		es.Indices.DeleteAlias.WithContext(ctx),
+		es.Indices.DeleteAlias.WithMasterTimeout(s.MasterTimeout),
+		es.Indices.DeleteAlias.WithTimeout(s.Timeout),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete aliases request")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read response body")
+		if res.IsError() {
+			return fmt.Errorf("elasticsearch delete alias error: [%d] (failed to read full body: %v)", res.StatusCode, err)
+		}
+		return errors.Wrap(err, "failed to read response body")
+	}
+	bodyString := string(bodyBytes)
+
+	if res.IsError() {
+		log.Error().
+			Int("status_code", res.StatusCode).
+			Str("response", bodyString).
+			Msg("Elasticsearch error response")
+		return fmt.Errorf("elasticsearch delete alias error: [%d] %s", res.StatusCode, bodyString)
+	}
+
+	log.Info().
+		Int("status_code", res.StatusCode).
+		Str("response", bodyString).
+		Msg("Alias deletion successful")
+
+	fmt.Println(bodyString)
+
+	return nil
+}

--- a/cmd/escuse-me/cmds/indices/indices.go
+++ b/cmd/escuse-me/cmds/indices/indices.go
@@ -5,92 +5,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var IndicesCmd = &cobra.Command{
+	Use:   "indices",
+	Short: "Indices related commands",
+}
+
 func AddToRootCommand(rootCmd *cobra.Command) error {
-	indicesCommand := &cobra.Command{
-		Use:   "indices",
-		Short: "ES indices related commands",
-	}
-	rootCmd.AddCommand(indicesCommand)
-
-	indicesListCommand, err := NewIndicesListCommand()
-	if err != nil {
-		return err
-	}
-	indicesListCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesListCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(indicesListCmd)
-
-	indicesStatsCommand, err := NewIndicesStatsCommand()
-	if err != nil {
-		return err
-	}
-	indicesStatsCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesStatsCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(indicesStatsCmd)
-
-	indicesGetMappingCommand, err := NewIndicesGetMappingCommand()
-	if err != nil {
-		return err
-	}
-	indicesGetMappingCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesGetMappingCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(indicesGetMappingCmd)
-
-	createIndexCommand, err := NewCreateIndexCommand()
-	if err != nil {
-		return err
-	}
-	createIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(createIndexCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(createIndexCmd)
-
-	deleteIndexCommand, err := NewDeleteIndexCommand()
-	if err != nil {
-		return err
-	}
-	deleteIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(deleteIndexCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(deleteIndexCmd)
-
-	updateMappingCommand, err := NewUpdateMappingCommand()
-	if err != nil {
-		return err
-	}
-	updateMappingCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(updateMappingCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(updateMappingCmd)
-
-	closeIndexCommand, err := NewCloseIndexCommand()
-	if err != nil {
-		return err
-	}
-	closeIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(closeIndexCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(closeIndexCmd)
-
-	cloneIndexCommand, err := NewCloneIndexCommand()
-	if err != nil {
-		return err
-	}
-	cloneIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(cloneIndexCommand)
-	if err != nil {
-		return err
-	}
-	indicesCommand.AddCommand(cloneIndexCmd)
+	indicesCommand := IndicesCmd
 
 	indicesGetAliasCommand, err := NewIndicesGetAliasCommand()
 	if err != nil {
@@ -100,7 +21,53 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+
+	indicesGetMappingsCommand, err := NewIndicesGetMappingCommand()
+	if err != nil {
+		return err
+	}
+	indicesGetMappingsCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesGetMappingsCommand)
+	if err != nil {
+		return err
+	}
+
+	indicesDeleteAliasCommand, err := NewIndicesDeleteAliasCommand()
+	if err != nil {
+		return err
+	}
+	// Assuming BuildCobraCommandWithEscuseMeMiddlewares works for BareCommand too
+	indicesDeleteAliasCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesDeleteAliasCommand)
+	if err != nil {
+		return err
+	}
+
+	// Add the new create-alias command
+	indicesCreateAliasCommand, err := NewIndicesCreateAliasCommand()
+	if err != nil {
+		return err
+	}
+	indicesCreateAliasCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesCreateAliasCommand)
+	if err != nil {
+		return err
+	}
+
+	// Add the new update-aliases command
+	indicesUpdateAliasesCommand, err := NewIndicesUpdateAliasesCommand()
+	if err != nil {
+		return err
+	}
+	indicesUpdateAliasesCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesUpdateAliasesCommand)
+	if err != nil {
+		return err
+	}
+
 	indicesCommand.AddCommand(indicesGetAliasCmd)
+	indicesCommand.AddCommand(indicesGetMappingsCmd)
+	indicesCommand.AddCommand(indicesDeleteAliasCmd)
+	indicesCommand.AddCommand(indicesCreateAliasCmd)   // Register create-alias
+	indicesCommand.AddCommand(indicesUpdateAliasesCmd) // Register update-aliases
+
+	rootCmd.AddCommand(indicesCommand)
 
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/indices.go
+++ b/cmd/escuse-me/cmds/indices/indices.go
@@ -5,13 +5,92 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var IndicesCmd = &cobra.Command{
-	Use:   "indices",
-	Short: "Indices related commands",
-}
-
 func AddToRootCommand(rootCmd *cobra.Command) error {
-	indicesCommand := IndicesCmd
+	indicesCommand := &cobra.Command{
+		Use:   "indices",
+		Short: "ES indices related commands",
+	}
+	rootCmd.AddCommand(indicesCommand)
+
+	indicesListCommand, err := NewIndicesListCommand()
+	if err != nil {
+		return err
+	}
+	indicesListCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesListCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(indicesListCmd)
+
+	indicesStatsCommand, err := NewIndicesStatsCommand()
+	if err != nil {
+		return err
+	}
+	indicesStatsCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesStatsCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(indicesStatsCmd)
+
+	indicesGetMappingCommand, err := NewIndicesGetMappingCommand()
+	if err != nil {
+		return err
+	}
+	indicesGetMappingCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesGetMappingCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(indicesGetMappingCmd)
+
+	createIndexCommand, err := NewCreateIndexCommand()
+	if err != nil {
+		return err
+	}
+	createIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(createIndexCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(createIndexCmd)
+
+	deleteIndexCommand, err := NewDeleteIndexCommand()
+	if err != nil {
+		return err
+	}
+	deleteIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(deleteIndexCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(deleteIndexCmd)
+
+	updateMappingCommand, err := NewUpdateMappingCommand()
+	if err != nil {
+		return err
+	}
+	updateMappingCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(updateMappingCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(updateMappingCmd)
+
+	closeIndexCommand, err := NewCloseIndexCommand()
+	if err != nil {
+		return err
+	}
+	closeIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(closeIndexCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(closeIndexCmd)
+
+	cloneIndexCommand, err := NewCloneIndexCommand()
+	if err != nil {
+		return err
+	}
+	cloneIndexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(cloneIndexCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(cloneIndexCmd)
 
 	indicesGetAliasCommand, err := NewIndicesGetAliasCommand()
 	if err != nil {
@@ -21,27 +100,18 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-
-	indicesGetMappingsCommand, err := NewIndicesGetMappingCommand()
-	if err != nil {
-		return err
-	}
-	indicesGetMappingsCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesGetMappingsCommand)
-	if err != nil {
-		return err
-	}
+	indicesCommand.AddCommand(indicesGetAliasCmd)
 
 	indicesDeleteAliasCommand, err := NewIndicesDeleteAliasCommand()
 	if err != nil {
 		return err
 	}
-	// Assuming BuildCobraCommandWithEscuseMeMiddlewares works for BareCommand too
 	indicesDeleteAliasCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesDeleteAliasCommand)
 	if err != nil {
 		return err
 	}
+	indicesCommand.AddCommand(indicesDeleteAliasCmd)
 
-	// Add the new create-alias command
 	indicesCreateAliasCommand, err := NewIndicesCreateAliasCommand()
 	if err != nil {
 		return err
@@ -50,8 +120,8 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	indicesCommand.AddCommand(indicesCreateAliasCmd)
 
-	// Add the new update-aliases command
 	indicesUpdateAliasesCommand, err := NewIndicesUpdateAliasesCommand()
 	if err != nil {
 		return err
@@ -60,14 +130,7 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-
-	indicesCommand.AddCommand(indicesGetAliasCmd)
-	indicesCommand.AddCommand(indicesGetMappingsCmd)
-	indicesCommand.AddCommand(indicesDeleteAliasCmd)
-	indicesCommand.AddCommand(indicesCreateAliasCmd)   // Register create-alias
-	indicesCommand.AddCommand(indicesUpdateAliasesCmd) // Register update-aliases
-
-	rootCmd.AddCommand(indicesCommand)
+	indicesCommand.AddCommand(indicesUpdateAliasesCmd)
 
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/indices.go
+++ b/cmd/escuse-me/cmds/indices/indices.go
@@ -92,5 +92,15 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	}
 	indicesCommand.AddCommand(cloneIndexCmd)
 
+	indicesGetAliasCommand, err := NewIndicesGetAliasCommand()
+	if err != nil {
+		return err
+	}
+	indicesGetAliasCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesGetAliasCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(indicesGetAliasCmd)
+
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/update-aliases.go
+++ b/cmd/escuse-me/cmds/indices/update-aliases.go
@@ -1,0 +1,155 @@
+package indices
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	glazed_layers "github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type IndicesUpdateAliasesCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.BareCommand = &IndicesUpdateAliasesCommand{}
+
+func NewIndicesUpdateAliasesCommand() (*IndicesUpdateAliasesCommand, error) {
+	glazedLayer, err := settings.NewGlazedParameterLayers(
+		settings.WithOutputParameterLayerOptions(
+			glazed_layers.WithDefaults(map[string]interface{}{
+				"output": "yaml", // Action command, minimal output expected
+			}),
+		),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+
+	esLayer, err := es_layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	return &IndicesUpdateAliasesCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"update-aliases",
+			cmds.WithShort("Performs multiple alias actions atomically"),
+			cmds.WithLong(`Allows performing one or more alias actions (add, remove) in a single atomic operation. Define actions in a JSON/YAML body.`),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"body",
+					parameters.ParameterTypeObjectFromFile, // Body containing actions is required
+					parameters.WithHelp("JSON/YAML object defining the 'actions' array (add/remove operations)"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"master_timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Specify timeout in seconds for connection to master node"),
+					parameters.WithDefault(30),
+				),
+				parameters.NewParameterDefinition(
+					"timeout",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Explicit operation timeout in seconds"),
+					parameters.WithDefault(30),
+				),
+			),
+			cmds.WithLayersList(glazedLayer, esLayer),
+		),
+	}, nil
+}
+
+type IndicesUpdateAliasesSettings struct {
+	// Body must contain the 'actions' for the API call
+	Body          map[string]interface{} `glazed.parameter:"body"`
+	MasterTimeout time.Duration          `glazed.parameter:"master_timeout"`
+	Timeout       time.Duration          `glazed.parameter:"timeout"`
+}
+
+func (c *IndicesUpdateAliasesCommand) Run(
+	ctx context.Context,
+	parsedLayers *glazed_layers.ParsedLayers,
+) error {
+	s := &IndicesUpdateAliasesSettings{}
+	err := parsedLayers.InitializeStruct(glazed_layers.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize settings struct")
+	}
+
+	es, err := es_layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	log.Debug().
+		Interface("body", s.Body).
+		Dur("master_timeout", s.MasterTimeout).
+		Dur("timeout", s.Timeout).
+		Msg("Updating aliases")
+
+	// Marshal the body which contains the actions
+	bodyBytes, err := json.Marshal(s.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal request body")
+	}
+	requestBody := bytes.NewReader(bodyBytes)
+	log.Debug().Str("body_json", string(bodyBytes)).Msg("Using request body for update actions")
+
+	options := []func(*esapi.IndicesUpdateAliasesRequest){
+		es.Indices.UpdateAliases.WithContext(ctx),
+		es.Indices.UpdateAliases.WithMasterTimeout(s.MasterTimeout),
+		es.Indices.UpdateAliases.WithTimeout(s.Timeout),
+		// Body is passed as the first argument to UpdateAliases
+	}
+
+	res, err := es.Indices.UpdateAliases(
+		requestBody, // The body containing the actions
+		options...,
+	)
+	if err != nil {
+		return errors.Wrap(err, "alias update request failed")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	respBodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read response body")
+		if res.IsError() {
+			return fmt.Errorf("elasticsearch update aliases error: [%d] (failed to read full body: %v)", res.StatusCode, err)
+		}
+		return errors.Wrap(err, "failed to read response body")
+	}
+	respBodyString := string(respBodyBytes)
+
+	if res.IsError() {
+		log.Error().
+			Int("status_code", res.StatusCode).
+			Str("response", respBodyString).
+			Msg("Elasticsearch error response")
+		return fmt.Errorf("elasticsearch update aliases error: [%d] %s", res.StatusCode, respBodyString)
+	}
+
+	log.Info().
+		Int("status_code", res.StatusCode).
+		Str("response", respBodyString).
+		Msg("Aliases updated successfully")
+
+	// Print the raw JSON response to standard output
+	fmt.Println(respBodyString)
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.17.0
 	github.com/go-go-golems/clay v0.1.38
 	github.com/go-go-golems/geppetto v0.4.47
-	github.com/go-go-golems/glazed v0.5.45
+	github.com/go-go-golems/glazed v0.5.46
 	github.com/go-go-golems/go-emrichen v0.0.7
-	github.com/go-go-golems/parka v0.5.24
+	github.com/go-go-golems/parka v0.5.25
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -147,12 +147,12 @@ github.com/go-go-golems/clay v0.1.38 h1:z53a8CsylLkFo/vexhuZQhcEB5XARPgvCpdPSPc1
 github.com/go-go-golems/clay v0.1.38/go.mod h1:iu+s1/Ng3r6FUKXI4NN0/P/E45MlpL3qkglvKhR7u+w=
 github.com/go-go-golems/geppetto v0.4.47 h1:+JGLUZJZEzGfb+MiGcceVv6y5Ye6P3/E/8nYp4Hi4PU=
 github.com/go-go-golems/geppetto v0.4.47/go.mod h1:Nlid0zl6WqEeUdO8SY9mIxOpXQD1x+BfuG6cUBsC6d4=
-github.com/go-go-golems/glazed v0.5.45 h1:GJNwguwECQ65qmkXUL3lN9jOGadnQcJImBVWjUn+Cs8=
-github.com/go-go-golems/glazed v0.5.45/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
+github.com/go-go-golems/glazed v0.5.46 h1:Trmil2uTS/yFdclW8jl0kic/vTaJQelEHq9xEtefmPc=
+github.com/go-go-golems/glazed v0.5.46/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
 github.com/go-go-golems/go-emrichen v0.0.7 h1:RSJajEihqieIWEo/X63DBY5N5tDl9JuZrFtxP2zImic=
 github.com/go-go-golems/go-emrichen v0.0.7/go.mod h1:2P4dTvCe7ystMW7mR2Wu58XXw5mF/0lH8lm6APYFpYQ=
-github.com/go-go-golems/parka v0.5.24 h1:RECUutFpfZQIUz1Zs12nII72JBzgv3iAmQtEYjkcNk0=
-github.com/go-go-golems/parka v0.5.24/go.mod h1:HgkuGjib39Wk0ZcIjtI1b1x/33fayHZLVgbirZw3ZKM=
+github.com/go-go-golems/parka v0.5.25 h1:J6Qt9Ou+ZFIMuF6zERx8x0fXxxeTLbjAzqxtAE3dP+U=
+github.com/go-go-golems/parka v0.5.25/go.mod h1:3kP5tDnIGY5soiodt6RIq10JMqL27bRd/+quQA9U3KQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/ttmp/2025-04-09/01-more-alias-commands-howto.md
+++ b/ttmp/2025-04-09/01-more-alias-commands-howto.md
@@ -1,0 +1,227 @@
+## Developer Guide: Adding Commands to `escuse-me`
+
+### 1. Project Overview
+
+`escuse-me` is a command-line interface (CLI) tool designed to interact with Elasticsearch clusters. It leverages the `glazed` framework for command structure, parameter handling, and structured output formatting (like tables, JSON, YAML). The goal is to provide convenient access to common Elasticsearch API operations directly from the terminal.
+
+The base Go package for this project is `github.com/go-go-golems/escuse-me`. It utilizes the official Go Elasticsearch client library `github.com/elastic/go-elasticsearch/v8`.
+
+### 2. Current Status: Alias Commands
+
+We are currently working on implementing commands related to Elasticsearch index aliases under the `indices` subcommand. So far, the following have been added:
+
+- **`indices aliases`**: Fetches and displays alias information.
+  - Implementation: `escuse-me/cmd/escuse-me/cmds/indices/alias.go`
+  - Uses: `esapi.IndicesGetAlias`
+- **`indices delete-alias`**: Deletes one or more aliases from specified indices.
+  - Implementation: `escuse-me/cmd/escuse-me/cmds/indices/delete_alias.go`
+  - Uses: `esapi.IndicesDeleteAlias`
+
+### 3. Goal: Completing Alias Commands & Beyond
+
+The immediate next steps are to implement the remaining standard alias operations:
+
+- **`indices create-alias`**: To add a new alias to one or more indices. (Likely using `esapi.IndicesPutAlias`)
+- **`indices update-aliases`**: To perform multiple alias operations (add, remove) atomically. (Likely using `esapi.IndicesUpdateAliases`)
+
+Beyond aliases, the same pattern can be used to add commands for other Elasticsearch APIs (e.g., document management, search, cluster health).
+
+### 4. Key Packages and Concepts
+
+- **`github.com/go-go-golems/glazed/pkg/cmds`**: Defines the core command interfaces (`Command`, `GlazeCommand`, `BareCommand`) and the `CommandDescription` struct.
+- **`github.com/go-go-golems/glazed/pkg/cmds/parameters`**: Used for defining command flags and arguments (`ParameterDefinition`, `ParameterType`, `WithHelp`, `WithDefault`, etc.).
+- **`github.com/go-go-golems/glazed/pkg/cmds/layers`**: Provides a way to group related parameters (like `glazed` output settings or ES connection settings). We use `ParsedLayers` to access parsed values.
+- **`github.com/go-go-golems/glazed/pkg/settings`**: Contains helpers for creating standard parameter layers, like `NewGlazedParameterLayers`.
+- **`github.com/go-go-golems/glazed/pkg/middlewares`**: The `Processor` interface (often `gp` variable) is used by `GlazeCommand` to output structured data.
+- **`github.com/go-go-golems/glazed/pkg/types`**: Defines `Row` for structured data output.
+- **`github.com/go-go-golems/glazed/pkg/cli`**: Contains functions like `BuildCobraCommandFromGlazeCommand` to convert `glazed` commands into `cobra` commands.
+- **`github.com/elastic/go-elasticsearch/v8/esapi`**: The Elasticsearch Go client API functions (e.g., `IndicesGetAlias`, `IndicesDeleteAlias`).
+- **`github.com/go-go-golems/escuse-me/pkg/cmds/layers`**: Defines custom layers specific to `escuse-me`, primarily `NewESParameterLayer` for Elasticsearch connection details.
+- **`github.com/go-go-golems/escuse-me/pkg/cmds`**: Contains helper functions like `BuildCobraCommandWithEscuseMeMiddlewares` which wraps `glazed/pkg/cli` functions to add `escuse-me` specific setup.
+- **`github.com/spf13/cobra`**: The underlying CLI framework used by `glazed`.
+
+### 5. Key Files
+
+- **`escuse-me/cmd/escuse-me/main.go`**: Entry point of the application, sets up the root cobra command.
+- **`escuse-me/cmd/escuse-me/cmds/indices/indices.go`**: Registers all commands under the `indices` subcommand. **New commands need to be added here.**
+- **`escuse-me/cmd/escuse-me/cmds/indices/*.go`**: Implementation files for individual `indices` subcommands (e.g., `alias.go`, `mappings.go`, `delete_alias.go`). **New command logic goes into new files here.**
+- **`escuse-me/pkg/cmds/layers/es.go`**: Defines the `ESParameterLayer` and the helper `NewESClientFromParsedLayers` to get an initialized Elasticsearch client based on command-line flags or environment variables.
+- **`escuse-me/pkg/cmds/cobra.go`**: Contains `BuildCobraCommandWithEscuseMeMiddlewares`.
+- **`glazed/prompto/glazed/create-command-tutorial.md`**: The general tutorial for creating `glazed` commands. Refer to this for foundational concepts.
+
+### 6. Workflow for Adding a New Command (e.g., `create-alias`)
+
+1.  **Create the Go File**: Create `escuse-me/cmd/escuse-me/cmds/indices/create_alias.go`.
+2.  **Define Command Struct**:
+
+    ```go
+    package indices
+
+    import (
+        // ... necessary imports: context, fmt, io, time, glazed/cmds, glazed/layers, glazed/parameters, glazed/settings, glazed/middlewares, es/layers, esapi, pkg/errors, log, etc.
+    )
+
+    type IndicesCreateAliasCommand struct {
+        *cmds.CommandDescription
+    }
+
+    // Decide on the command type. For create/update/delete, often a simple confirmation is needed.
+    // A BareCommand or WriterCommand might be suitable if you just print the ES response.
+    // Let's assume BareCommand for now, as Glaze tables aren't the primary output.
+    var _ cmds.BareCommand = &IndicesCreateAliasCommand{} // Or cmds.GlazeCommand / cmds.WriterCommand
+    ```
+
+3.  **Create Constructor (`New...`)**:
+
+    ```go
+    func NewIndicesCreateAliasCommand() (*IndicesCreateAliasCommand, error) {
+        // Create standard glazed layer (might customize if not outputting tables)
+        glazedLayer, err := settings.NewGlazedParameterLayers( /* options? */)
+        if err != nil { /* handle error */ }
+
+        // Create ES connection layer
+        esLayer, err := layers.NewESParameterLayer()
+        if err != nil { /* handle error */ }
+
+        return &IndicesCreateAliasCommand{
+            CommandDescription: cmds.NewCommandDescription(
+                "create-alias",
+                cmds.WithShort("Creates an index alias"),
+                cmds.WithFlags(
+                    // Define flags using parameters.NewParameterDefinition
+                    // Example: Index name(s), Alias name, Filter (JSON string?), Routing, IsWriteIndex etc.
+                    // Refer to esapi.IndicesPutAliasRequest documentation for needed fields.
+                    parameters.NewParameterDefinition(
+                        "index",
+                        parameters.ParameterTypeStringList,
+                        parameters.WithHelp("Index name(s) to add the alias to"),
+                        parameters.WithRequired(true),
+                    ),
+                    parameters.NewParameterDefinition(
+                        "name",
+                        parameters.ParameterTypeString, // Typically one alias name per creation via PutAlias
+                        parameters.WithHelp("The name of the alias to create"),
+                        parameters.WithRequired(true),
+                    ),
+                    parameters.NewParameterDefinition(
+                        "body", // Often easier to pass complex things like filters as JSON
+                        parameters.ParameterTypeObjectFromFile, // Reads JSON/YAML from file or stdin
+                        parameters.WithHelp("JSON object defining alias properties (filter, routing, is_write_index)"),
+                        parameters.WithOptional(true), // Optional if no filter/routing needed
+                    ),
+                    // Add other relevant flags: timeout, master_timeout etc.
+                    parameters.NewParameterDefinition(
+                        "timeout",
+                        parameters.ParameterTypeInteger,
+                        parameters.WithHelp("Explicit operation timeout in seconds"),
+                        parameters.WithDefault(30),
+                    ),
+                ),
+                cmds.WithLayersList(glazedLayer, esLayer),
+            ),
+        }, nil
+    }
+    ```
+
+4.  **Define Settings Struct**:
+    ```go
+    type IndicesCreateAliasSettings struct {
+        Index         []string               `glazed.parameter:"index"`
+        Name          string                 `glazed.parameter:"name"`
+        Body          map[string]interface{} `glazed.parameter:"body"` // Parsed from --body flag
+        Timeout       time.Duration          `glazed.parameter:"timeout"`
+        // Add other fields matching flag names
+    }
+    ```
+5.  **Implement `Run` Method (for `BareCommand`)**:
+
+    ```go
+    func (c *IndicesCreateAliasCommand) Run(
+        ctx context.Context,
+        parsedLayers *layers.ParsedLayers,
+    ) error {
+        s := &IndicesCreateAliasSettings{}
+        err := parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+        if err != nil { return errors.Wrap(err, "...") }
+
+        es, err := layers.NewESClientFromParsedLayers(parsedLayers)
+        if err != nil { return errors.Wrap(err, "...") }
+
+        log.Debug().Str("name", s.Name).Strs("indices", s.Index).Msg("Creating alias")
+
+        // Prepare options for the ES API call
+        options := []func(*esapi.IndicesPutAliasRequest){
+            es.Indices.PutAlias.WithContext(ctx),
+            es.Indices.PutAlias.WithTimeout(s.Timeout),
+            // Add master_timeout, etc.
+        }
+
+        // Handle the body if provided
+        var requestBody io.Reader
+        if s.Body != nil && len(s.Body) > 0 {
+            bodyBytes, err := json.Marshal(s.Body)
+            if err != nil {
+                return errors.Wrap(err, "failed to marshal request body")
+            }
+            requestBody = bytes.NewReader(bodyBytes)
+            options = append(options, es.Indices.PutAlias.WithBody(requestBody))
+        }
+
+
+        // Make the call (Indices.PutAlias)
+        res, err := es.Indices.PutAlias(
+            s.Index, // Target indices
+            s.Name,  // Alias name
+            options...,
+        )
+        if err != nil { return errors.Wrap(err, "...") }
+        defer res.Body.Close()
+
+        // Process response (check for errors, print confirmation)
+        bodyBytes, err := io.ReadAll(res.Body)
+        if err != nil { return errors.Wrap(err, "failed to read response body") }
+        bodyString := string(bodyBytes)
+
+        if res.IsError() {
+            log.Error().Int("status", res.StatusCode).Str("body", bodyString).Msg("Failed to create alias")
+            return fmt.Errorf("elasticsearch error [%d]: %s", res.StatusCode, bodyString)
+        }
+
+        log.Info().Int("status", res.StatusCode).Str("body", bodyString).Msg("Alias created successfully")
+        fmt.Println(bodyString) // Print the success response (usually {"acknowledged": true})
+
+        return nil
+    }
+
+    // If using GlazeCommand, implement RunIntoGlazeProcessor instead and use gp.AddRow
+    // If using WriterCommand, implement RunIntoWriter and use w.Write
+    ```
+
+6.  **Register Command**: Open `escuse-me/cmd/escuse-me/cmds/indices/indices.go` and add:
+
+    ```go
+    // ... inside AddToRootCommand function ...
+
+    indicesCreateAliasCommand, err := NewIndicesCreateAliasCommand()
+    if err != nil {
+        return err
+    }
+    // Use the helper to add middlewares (like logging)
+    indicesCreateAliasCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(indicesCreateAliasCommand)
+    if err != nil {
+        return err
+    }
+    indicesCommand.AddCommand(indicesCreateAliasCmd)
+
+    // ... rest of the function ...
+    ```
+
+7.  **Build and Test**: Run `go build ./cmd/escuse-me` and test the new command against an Elasticsearch instance.
+
+### 7. Next Steps
+
+1.  Implement `IndicesCreateAliasCommand` following the steps above, using `esapi.IndicesPutAlias`.
+2.  Implement `IndicesUpdateAliasesCommand` using `esapi.IndicesUpdateAliases`. This API call usually takes a structured body defining multiple `add` and `remove` actions, so the `--body` flag (using `ParameterTypeObjectFromFile`) will be crucial.
+3.  Continue adding other useful Elasticsearch commands following the established pattern.
+
+Good luck! Remember to check the `esapi` documentation for the specific requirements of each API call.


### PR DESCRIPTION
This PR adds a complete set of commands for managing Elasticsearch index aliases:

* `indices aliases` - List and query existing aliases with filtering options
* `indices create-alias` - Create or update an alias for one or more indices
* `indices delete-alias` - Remove aliases from specified indices
* `indices update-aliases` - Perform multiple alias operations atomically

These commands provide full coverage of the Elasticsearch alias API, allowing
users to:

* View all aliases or filter by index/alias name
* Create aliases with optional filters, routing, and write index settings
* Delete aliases from specific indices
* Perform atomic alias operations (useful for zero-downtime index migrations)

Also includes a developer guide for adding new commands to escuse-me.