### PR TITLE
Add dump and reindex commands for Elasticsearch indices

### DIFF
--- a/cmd/escuse-me/cmds/documents/bulk-index.go
+++ b/cmd/escuse-me/cmds/documents/bulk-index.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds"
@@ -14,7 +16,6 @@ import (
 	"github.com/go-go-golems/glazed/pkg/settings"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
-	"io"
 )
 
 func interleaveBulkIndexObjects(objects []map[string]interface{}, index string) (io.Reader, error) {
@@ -108,8 +109,6 @@ func NewBulkIndexCommand() (*BulkIndexCommand, error) {
 					parameters.ParameterTypeBool,
 					parameters.WithHelp("If true, the request's actions must target an index alias"),
 				),
-			),
-			cmds.WithArguments(
 				parameters.NewParameterDefinition(
 					"files",
 					parameters.ParameterTypeObjectListFromFiles,

--- a/cmd/escuse-me/cmds/indices/clone.go
+++ b/cmd/escuse-me/cmds/indices/clone.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"log"
 	"strings"
 
 	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
@@ -17,6 +16,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/settings"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type CloneIndexCommand struct {
@@ -145,7 +145,7 @@ func (c *CloneIndexCommand) RunIntoGlazeProcessor(
 			es.Indices.PutSettings.WithContext(ctx),
 		)
 		if revertErr != nil {
-			log.Printf("WARN: failed to remove write block from index %s: %v", s.Index, revertErr)
+			log.Warn().Err(revertErr).Str("index", s.Index).Msg("Failed to remove write block from index")
 			return
 		}
 		defer func(Body io.ReadCloser) {
@@ -154,7 +154,7 @@ func (c *CloneIndexCommand) RunIntoGlazeProcessor(
 
 		if revertRes.IsError() {
 			bodyBytes, _ := io.ReadAll(revertRes.Body)
-			log.Printf("WARN: failed to remove write block from index %s: %s", s.Index, string(bodyBytes))
+			log.Warn().Str("index", s.Index).Str("response", string(bodyBytes)).Msg("Failed to remove write block from index")
 		}
 	}()
 

--- a/cmd/escuse-me/cmds/indices/clone.go
+++ b/cmd/escuse-me/cmds/indices/clone.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"log"
+	"strings"
+
 	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
 	"github.com/go-go-golems/escuse-me/pkg/helpers"
 	"github.com/go-go-golems/glazed/pkg/cmds"
@@ -13,7 +17,6 @@ import (
 	"github.com/go-go-golems/glazed/pkg/settings"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
-	"io"
 )
 
 type CloneIndexCommand struct {
@@ -35,7 +38,29 @@ func NewCloneIndexCommand() (*CloneIndexCommand, error) {
 	return &CloneIndexCommand{
 		CommandDescription: cmds.NewCommandDescription(
 			"clone",
-			cmds.WithShort("Clones an index"),
+			cmds.WithShort("Clones an existing Elasticsearch index"),
+			cmds.WithLong(`Clones an existing Elasticsearch index into a new target index.
+
+The clone operation creates a new index with the same mappings and most settings as the source index. 
+It achieves this efficiently by hard-linking segments from the source index to the target index 
+(if the underlying filesystem supports it; otherwise, segments are copied).
+
+Prerequisites:
+- The source index must be marked as read-only (use 'index.blocks.write=true'). This command handles setting and unsetting this automatically.
+- The source index cluster health status must be green.
+
+What is copied:
+- Index mappings.
+- Most index settings.
+
+What is NOT copied by default:
+- Index metadata (aliases, ILM phase definitions, CCR follower info).
+- Replica settings ('index.number_of_replicas', 'index.auto_expand_replicas'). These can be set using the --settings flag.
+
+See: 
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clone-index.html
+- https://opster.com/guides/elasticsearch/operations/elasticsearch-clone-index/
+`),
 			cmds.WithFlags(
 				parameters.NewParameterDefinition(
 					"index",
@@ -93,7 +118,47 @@ func (c *CloneIndexCommand) RunIntoGlazeProcessor(
 		return err
 	}
 
-	cloneIndexRequest := map[string]interface{}{}
+	// Set index to read-only before cloning
+	readOnlySettings := strings.NewReader(`{"index": {"blocks": {"write": true}}}`)
+	res, err := es.Indices.PutSettings(
+		readOnlySettings,
+		es.Indices.PutSettings.WithIndex(s.Index),
+		es.Indices.PutSettings.WithContext(ctx),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to set index to read-only")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+	if res.IsError() {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return errors.Errorf("failed to set index to read-only: %s", string(bodyBytes))
+	}
+
+	// Ensure index write block is removed afterwards
+	defer func() {
+		revertSettings := strings.NewReader(`{"index": {"blocks": {"write": null}}}`)
+		revertRes, revertErr := es.Indices.PutSettings(
+			revertSettings,
+			es.Indices.PutSettings.WithIndex(s.Index),
+			es.Indices.PutSettings.WithContext(ctx),
+		)
+		if revertErr != nil {
+			log.Printf("WARN: failed to remove write block from index %s: %v", s.Index, revertErr)
+			return
+		}
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(revertRes.Body)
+
+		if revertRes.IsError() {
+			bodyBytes, _ := io.ReadAll(revertRes.Body)
+			log.Printf("WARN: failed to remove write block from index %s: %s", s.Index, string(bodyBytes))
+		}
+	}()
+
+	cloneIndexRequest := map[string]any{}
 	if s.Settings != nil {
 		cloneIndexRequest["settings"] = s.Settings
 	}

--- a/cmd/escuse-me/cmds/indices/dump.go
+++ b/cmd/escuse-me/cmds/indices/dump.go
@@ -1,0 +1,355 @@
+package indices
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type DumpSettings struct {
+	Index         string                 `glazed.parameter:"index"`
+	Query         map[string]interface{} `glazed.parameter:"query"`
+	Limit         int                    `glazed.parameter:"limit"`
+	BulkFormat    bool                   `glazed.parameter:"bulk-format"`
+	TargetIndex   string                 `glazed.parameter:"target-index"`
+	Action        string                 `glazed.parameter:"action"`
+	BatchSize     int                    `glazed.parameter:"batch-size"`
+	PitKeepAlive  string                 `glazed.parameter:"pit-keep-alive"`
+	PitKeepAliveD time.Duration
+}
+
+type DumpCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.GlazeCommand = &DumpCommand{}
+
+func NewDumpCommand() (*DumpCommand, error) {
+	glazedParameterLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+	esParameterLayer, err := es_layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	cmd := &DumpCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"dump",
+			cmds.WithShort("Dumps documents from an Elasticsearch index using PIT/search_after"),
+			cmds.WithLong(`Retrieves documents from the specified Elasticsearch index(es) 
+using the Point in Time (PIT) API and search_after for efficient pagination. 
+Supports filtering via Query DSL and multiple output formats, including one 
+compatible with the 'documents bulk' command.
+
+Use --bulk-format for output suitable for 'escuse-me documents bulk'.
+Otherwise, use standard Glazed flags (-o, --fields) for inspection.
+`),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"index",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Index name or pattern to dump from"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"query",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("JSON query object (DSL) to filter documents (default: match_all)"),
+					parameters.WithDefault(map[string]interface{}{"query": map[string]interface{}{"match_all": map[string]interface{}{}}}),
+				),
+				parameters.NewParameterDefinition(
+					"limit",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Maximum number of documents to dump (-1 for no limit)"),
+					parameters.WithDefault(-1),
+				),
+				parameters.NewParameterDefinition(
+					"bulk-format",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Output in Elasticsearch Bulk API format (for 'documents bulk')"),
+					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"target-index",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Index name for the bulk action line (used only with --bulk-format)"),
+				),
+				parameters.NewParameterDefinition(
+					"action",
+					parameters.ParameterTypeChoice,
+					parameters.WithHelp("Bulk action type (used only with --bulk-format)"),
+					parameters.WithChoices("index", "create"),
+					parameters.WithDefault("index"),
+				),
+				parameters.NewParameterDefinition(
+					"batch-size",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Number of documents to retrieve per search request"),
+					parameters.WithDefault(1000),
+				),
+				parameters.NewParameterDefinition(
+					"pit-keep-alive",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Point in Time keep-alive duration (e.g., '5m', '1h')"),
+					parameters.WithDefault("5m"),
+				),
+			),
+			cmds.WithLayersList(glazedParameterLayer, esParameterLayer),
+		),
+	}
+
+	return cmd, nil
+}
+
+func (c *DumpCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *layers.ParsedLayers,
+	gp middlewares.Processor,
+) error {
+	s := &DumpSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return errors.Wrap(err, "failed to initialize settings")
+	}
+
+	var err error
+	s.PitKeepAliveD, err = time.ParseDuration(s.PitKeepAlive)
+	if err != nil {
+		return errors.Wrapf(err, "invalid PIT keep-alive duration: %s", s.PitKeepAlive)
+	}
+
+	es, err := es_layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	log.Debug().Str("index", s.Index).Str("keepAlive", s.PitKeepAlive).Msg("Opening Point in Time (PIT)")
+	pitRes, err := es.OpenPointInTime(
+		[]string{s.Index},
+		s.PitKeepAlive,
+		es.OpenPointInTime.WithContext(ctx),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to open Point in Time")
+	}
+	if pitRes.IsError() {
+		bodyBytes, _ := io.ReadAll(pitRes.Body)
+		_ = pitRes.Body.Close()
+		return errors.Errorf("failed to open Point in Time: %s", string(bodyBytes))
+	}
+
+	var pitResult struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(pitRes.Body).Decode(&pitResult); err != nil {
+		_ = pitRes.Body.Close()
+		return errors.Wrap(err, "failed to decode PIT response")
+	}
+	_ = pitRes.Body.Close()
+	pitID := pitResult.ID
+	log.Debug().Str("pitID", pitID).Msg("PIT opened successfully")
+
+	// Ensure PIT is closed eventually
+	defer func() {
+		log.Debug().Str("pitID", pitID).Msg("Closing PIT")
+		closeBody := map[string]string{"id": pitID}
+		bodyBytes, err := json.Marshal(closeBody)
+		if err != nil {
+			log.Warn().Err(err).Str("pitID", pitID).Msg("Failed to marshal close PIT request body")
+			return
+		}
+		closeRes, err := es.ClosePointInTime(
+			es.ClosePointInTime.WithBody(bytes.NewReader(bodyBytes)),
+			es.ClosePointInTime.WithContext(context.Background()), // Use background context for cleanup
+		)
+		if err != nil {
+			log.Warn().Err(err).Str("pitID", pitID).Msg("Failed API call to close PIT")
+			return
+		}
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(closeRes.Body)
+		if closeRes.IsError() {
+			bodyBytes, readErr := io.ReadAll(closeRes.Body)
+			if readErr != nil {
+				log.Warn().Err(readErr).Str("pitID", pitID).Msg("Failed to read error response body when closing PIT")
+				return
+			}
+			log.Warn().Str("pitID", pitID).Str("response", string(bodyBytes)).Msg("Failed to close PIT")
+		} else {
+			log.Debug().Str("pitID", pitID).Msg("PIT closed successfully.")
+		}
+	}()
+
+	var searchAfter []interface{}
+	totalDocsDumped := 0
+	var outputWriter *bufio.Writer
+	if s.BulkFormat {
+		// For bulk format, write directly to stdout, bypassing Glazed processor
+		outputWriter = bufio.NewWriter(os.Stdout)
+		defer func() {
+			_ = outputWriter.Flush() // Ensure buffer is flushed at the end
+		}()
+	}
+
+	for {
+		log.Debug().Int("batchSize", s.BatchSize).Interface("searchAfter", searchAfter).Msg("Fetching batch")
+
+		searchBody := map[string]interface{}{
+			"size": s.BatchSize,
+			"pit": map[string]interface{}{
+				"id":         pitID,
+				"keep_alive": s.PitKeepAlive,
+			},
+			"sort": []map[string]string{
+				{"_shard_doc": "asc"}, // Essential for search_after with PIT
+			},
+		}
+
+		// Correctly assign the query content
+		if queryContent, ok := s.Query["query"]; ok {
+			searchBody["query"] = queryContent // Use the inner content if top-level 'query' key exists
+		} else {
+			searchBody["query"] = s.Query // Assume the whole object is the query content otherwise
+		}
+
+		if searchAfter != nil {
+			searchBody["search_after"] = searchAfter
+		}
+
+		bodyBytes, err := json.Marshal(searchBody)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal search request body")
+		}
+
+		searchRes, err := es.Search(
+			es.Search.WithContext(ctx),
+			es.Search.WithBody(bytes.NewReader(bodyBytes)),
+		)
+		if err != nil {
+			return errors.Wrap(err, "search request failed")
+		}
+
+		bodyBytes, readErr := io.ReadAll(searchRes.Body)
+		closeErr := searchRes.Body.Close()
+		if readErr != nil {
+			return errors.Wrap(err, "failed to read search response body")
+		}
+		if closeErr != nil {
+			log.Warn().Err(closeErr).Msg("Failed to close search response body")
+		}
+
+		if searchRes.IsError() {
+			return errors.Errorf("search request failed: %s", string(bodyBytes))
+		}
+
+		// Decode the successful response
+		var searchResult struct {
+			Hits struct {
+				Total struct {
+					Value int `json:"value"`
+				} `json:"total"`
+				Hits []struct {
+					ID     string                 `json:"_id"`
+					Index  string                 `json:"_index"`
+					Source map[string]interface{} `json:"_source"`
+					Sort   []interface{}          `json:"sort"`
+				} `json:"hits"`
+			} `json:"hits"`
+		}
+
+		if err := json.Unmarshal(bodyBytes, &searchResult); err != nil {
+			return errors.Wrapf(err, "failed to decode search response: %s", string(bodyBytes))
+		}
+
+		hits := searchResult.Hits.Hits
+		if len(hits) == 0 {
+			log.Debug().Msg("No more documents found. Dump finished.")
+			break // Exit the loop when no more hits are returned
+		}
+
+		log.Debug().Int("hitCount", len(hits)).Msg("Processing hits")
+
+		for _, hit := range hits {
+			if s.Limit >= 0 && totalDocsDumped >= s.Limit {
+				log.Debug().Int("limit", s.Limit).Msg("Reached document limit. Stopping dump.")
+				return nil // Use return to trigger the deferred PIT close
+			}
+
+			if s.BulkFormat {
+				// Write Action/Metadata line
+				actionMetadata := map[string]interface{}{
+					s.Action: map[string]interface{}{
+						"_index": s.TargetIndex,
+						"_id":    hit.ID,
+					},
+				}
+				// Use original index if target-index is not specified
+				if s.TargetIndex == "" {
+					actionMetadata[s.Action].(map[string]interface{})["_index"] = hit.Index
+				}
+
+				actionBytes, err := json.Marshal(actionMetadata)
+				if err != nil {
+					return errors.Wrapf(err, "failed to marshal bulk action for doc %s", hit.ID)
+				}
+				_, _ = outputWriter.Write(actionBytes)
+				_, _ = outputWriter.WriteString("\n")
+
+				// Write Source line
+				sourceBytes, err := json.Marshal(hit.Source)
+				if err != nil {
+					return errors.Wrapf(err, "failed to marshal source for doc %s", hit.ID)
+				}
+				_, _ = outputWriter.Write(sourceBytes)
+				_, _ = outputWriter.WriteString("\n")
+
+			} else {
+				// Output using Glazed processor
+				// Create a row including _id, _index, and fields from _source
+				rowMap := map[string]interface{}{
+					"_id":    hit.ID,
+					"_index": hit.Index,
+				}
+				for k, v := range hit.Source {
+					rowMap[fmt.Sprintf("_source.%s", k)] = v
+				}
+				row := types.NewRowFromMap(rowMap)
+
+				if err := gp.AddRow(ctx, row); err != nil {
+					return errors.Wrapf(err, "failed to add row to Glaze processor for doc %s", hit.ID)
+				}
+			}
+
+			totalDocsDumped++
+		}
+
+		// Update search_after with the sort values of the last hit in this batch
+		searchAfter = hits[len(hits)-1].Sort
+
+		// Check limit again after processing the batch
+		if s.Limit >= 0 && totalDocsDumped >= s.Limit {
+			log.Debug().Int("limit", s.Limit).Msg("Reached document limit after processing batch. Stopping dump.")
+			break // Use break to allow deferred PIT close to run cleanly
+		}
+	}
+
+	log.Debug().Int("totalDocs", totalDocsDumped).Msg("Dump finished.")
+	return nil
+}

--- a/cmd/escuse-me/cmds/indices/indices.go
+++ b/cmd/escuse-me/cmds/indices/indices.go
@@ -142,5 +142,14 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	}
 	indicesCommand.AddCommand(reindexCmd)
 
+	dumpCommand, err := NewDumpCommand()
+	if err != nil {
+		return err
+	}
+	dumpCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(dumpCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(dumpCmd)
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/indices.go
+++ b/cmd/escuse-me/cmds/indices/indices.go
@@ -132,5 +132,15 @@ func AddToRootCommand(rootCmd *cobra.Command) error {
 	}
 	indicesCommand.AddCommand(indicesUpdateAliasesCmd)
 
+	reindexCommand, err := NewReindexCommand()
+	if err != nil {
+		return err
+	}
+	reindexCmd, err := es_cmds.BuildCobraCommandWithEscuseMeMiddlewares(reindexCommand)
+	if err != nil {
+		return err
+	}
+	indicesCommand.AddCommand(reindexCmd)
+
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/reindex.go
+++ b/cmd/escuse-me/cmds/indices/reindex.go
@@ -1,0 +1,599 @@
+package indices
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	es_layers "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+)
+
+type ReindexSettings struct {
+	SourceIndex          string                 `glazed.parameter:"source-index"`
+	TargetIndex          string                 `glazed.parameter:"target-index"`
+	Query                map[string]interface{} `glazed.parameter:"query"`
+	Script               map[string]interface{} `glazed.parameter:"script"`
+	Pipeline             string                 `glazed.parameter:"pipeline"`
+	BatchSize            int                    `glazed.parameter:"batch-size"`
+	Slices               int                    `glazed.parameter:"slices"`
+	RequestsPerSecond    float32                `glazed.parameter:"requests-per-second"`
+	WaitForCompletion    bool                   `glazed.parameter:"wait-for-completion"`
+	PollInterval         string                 `glazed.parameter:"poll-interval"`
+	CreateTarget         bool                   `glazed.parameter:"create-target"`
+	TargetSettings       map[string]interface{} `glazed.parameter:"target-settings"`
+	TargetMappings       map[string]interface{} `glazed.parameter:"target-mappings"`
+	SwapAlias            string                 `glazed.parameter:"swap-alias"`
+	Timeout              string                 `glazed.parameter:"timeout"`
+	PollIntervalDuration time.Duration
+	TimeoutDuration      time.Duration
+}
+
+type ReindexCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.GlazeCommand = &ReindexCommand{}
+
+func NewReindexCommand() (*ReindexCommand, error) {
+	glazedParameterLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+	esParameterLayer, err := es_layers.NewESParameterLayer()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create ES parameter layer")
+	}
+
+	cmd := &ReindexCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"reindex",
+			cmds.WithShort("Reindexes documents from a source index to a target index"),
+			cmds.WithLong(`Initiates and monitors an Elasticsearch _reindex operation.
+
+Allows copying documents from a source index to a target index, potentially 
+filtering, transforming, and changing settings/mappings in the process.
+
+Features:
+- Filter source documents with a query.
+- Transform documents using scripts or ingest pipelines.
+- Optionally create the target index with specific settings/mappings.
+- Runs asynchronously by default, monitoring progress via the Tasks API.
+- Provides streaming progress updates (using glazed output).
+- Optionally swaps an alias atomically upon successful completion.
+- Control batch size, parallelization (slices), and throttling.
+`),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"source-index",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Source index name(s) (comma-separated or wildcards)"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"target-index",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Target index name"),
+					parameters.WithRequired(true),
+				),
+				parameters.NewParameterDefinition(
+					"query",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("JSON query object to filter source documents (from file or stdin)"),
+				),
+				parameters.NewParameterDefinition(
+					"script",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("JSON script object {\"source\": \"...\", \"lang\": \"...\", \"params\": {...}} for transformation"),
+				),
+				parameters.NewParameterDefinition(
+					"pipeline",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Ingest pipeline name to apply during reindexing"),
+				),
+				parameters.NewParameterDefinition(
+					"batch-size",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Number of documents to process in each batch (source.size)"),
+					parameters.WithDefault(1000),
+				),
+				parameters.NewParameterDefinition(
+					"slices",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("Number of slices for parallel processing (set > 1 or 'auto')"),
+					// NOTE(manuel) we might want to support auto later, requires different handling
+					parameters.WithDefault(1),
+				),
+				parameters.NewParameterDefinition(
+					"requests-per-second",
+					parameters.ParameterTypeFloat,
+					parameters.WithHelp("Throttle rate (documents per second, -1 for unlimited)"),
+					parameters.WithDefault(float32(-1.0)),
+				),
+				parameters.NewParameterDefinition(
+					"wait-for-completion",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Run synchronously and wait for completion instead of monitoring task"),
+					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"poll-interval",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Frequency to poll task status (e.g., '5s', '1m')"),
+					parameters.WithDefault("5s"),
+				),
+				parameters.NewParameterDefinition(
+					"create-target",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Create the target index if it doesn't exist (requires --target-settings or --target-mappings)"),
+					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"target-settings",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("JSON settings object for target index creation (used if --create-target is true)"),
+				),
+				parameters.NewParameterDefinition(
+					"target-mappings",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("JSON mappings object for target index creation (used if --create-target is true)"),
+				),
+				parameters.NewParameterDefinition(
+					"swap-alias",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Alias name to atomically move from source to target on success"),
+				),
+				parameters.NewParameterDefinition(
+					"timeout",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Overall timeout for the reindex request coordination (e.g., '1m', '30s')"),
+					parameters.WithDefault("1m"),
+				),
+			),
+			cmds.WithLayersList(glazedParameterLayer, esParameterLayer),
+		),
+	}
+
+	return cmd, nil
+}
+
+func (c *ReindexCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *layers.ParsedLayers,
+	gp middlewares.Processor,
+) error {
+	s := &ReindexSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return errors.Wrap(err, "failed to initialize settings")
+	}
+
+	// Parse duration strings
+	var err error
+	s.PollIntervalDuration, err = time.ParseDuration(s.PollInterval)
+	if err != nil {
+		return errors.Wrapf(err, "invalid poll interval duration: %s", s.PollInterval)
+	}
+	s.TimeoutDuration, err = time.ParseDuration(s.Timeout)
+	if err != nil {
+		return errors.Wrapf(err, "invalid timeout duration: %s", s.Timeout)
+	}
+
+	es, err := es_layers.NewESClientFromParsedLayers(parsedLayers)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ES client")
+	}
+
+	// Handle target index creation
+	if s.CreateTarget {
+		log.Printf("Checking if target index '%s' exists...\n", s.TargetIndex)
+		existsRes, err := es.Indices.Exists([]string{s.TargetIndex}, es.Indices.Exists.WithContext(ctx))
+		if err != nil {
+			return errors.Wrapf(err, "failed to check if target index '%s' exists", s.TargetIndex)
+		}
+		_ = existsRes.Body.Close() // Ignore error, status code is enough
+
+		if existsRes.StatusCode == http.StatusNotFound {
+			log.Printf("Target index '%s' does not exist. Creating...\n", s.TargetIndex)
+			if s.TargetSettings == nil && s.TargetMappings == nil {
+				return errors.New("--create-target requires --target-settings and/or --target-mappings to be provided")
+			}
+
+			createBody := map[string]interface{}{}
+			if s.TargetSettings != nil {
+				createBody["settings"] = s.TargetSettings
+			}
+			if s.TargetMappings != nil {
+				createBody["mappings"] = s.TargetMappings
+			}
+
+			bodyBytes, err := json.Marshal(createBody)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal create index request body")
+			}
+
+			createRes, err := es.Indices.Create(
+				s.TargetIndex,
+				es.Indices.Create.WithContext(ctx),
+				es.Indices.Create.WithBody(bytes.NewReader(bodyBytes)),
+			)
+			if err != nil {
+				return errors.Wrapf(err, "failed to create target index '%s'", s.TargetIndex)
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(createRes.Body)
+
+			if createRes.IsError() {
+				bodyBytes, _ := io.ReadAll(createRes.Body)
+				return errors.Errorf("failed to create target index '%s': %s", s.TargetIndex, string(bodyBytes))
+			}
+			log.Printf("Target index '%s' created successfully.\n", s.TargetIndex)
+		} else if existsRes.IsError() {
+			// Handle other errors during exists check
+			return errors.Errorf("error checking existence of target index '%s': status %d", s.TargetIndex, existsRes.StatusCode)
+		} else {
+			log.Printf("Target index '%s' already exists. Skipping creation.\n", s.TargetIndex)
+		}
+	}
+
+	// Prepare _reindex request body
+	log.Println("Preparing reindex request body...")
+	reindexBody := map[string]interface{}{
+		"source": map[string]interface{}{
+			"index": s.SourceIndex,
+			"size":  s.BatchSize,
+		},
+		"dest": map[string]interface{}{
+			"index": s.TargetIndex,
+			// Consider making op_type configurable later if needed
+			"op_type": "create",
+		},
+	}
+	if s.Query != nil {
+		reindexBody["source"].(map[string]interface{})["query"] = s.Query
+	}
+	if s.Pipeline != "" {
+		reindexBody["dest"].(map[string]interface{})["pipeline"] = s.Pipeline
+	}
+	if s.Script != nil {
+		reindexBody["script"] = s.Script
+	}
+
+	bodyBytes, err := json.Marshal(reindexBody)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal reindex request body")
+	}
+
+	// Prepare reindex options
+	reindexOptions := []func(*esapi.ReindexRequest){
+		es.Reindex.WithContext(ctx),
+		es.Reindex.WithWaitForCompletion(s.WaitForCompletion),
+		es.Reindex.WithTimeout(s.TimeoutDuration),
+	}
+	if s.Slices > 0 { // ES default is 1, only set if different
+		// NOTE: Using s.Slices directly might be better than > 1 check if 'auto' needs specific value?
+		reindexOptions = append(reindexOptions, es.Reindex.WithSlices(int64(s.Slices)))
+	}
+	if s.RequestsPerSecond >= 0 { // ES default is -1 (unlimited)
+		reindexOptions = append(reindexOptions, es.Reindex.WithRequestsPerSecond(int(s.RequestsPerSecond)))
+	}
+
+	// Execute _reindex API call
+	log.Printf("Starting reindex from '%s' to '%s' (WaitForCompletion: %t)...\n",
+		s.SourceIndex, s.TargetIndex, s.WaitForCompletion)
+
+	res, err := es.Reindex(bytes.NewReader(bodyBytes), reindexOptions...)
+	if err != nil {
+		return errors.Wrap(err, "reindex API call failed")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	if res.IsError() {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return errors.Errorf("reindex request failed: %s", string(bodyBytes))
+	}
+
+	var taskID string
+	var finalTaskStatus map[string]interface{}
+	reindexSuccessful := false
+
+	// Process Response
+	if s.WaitForCompletion {
+		log.Println("Reindex running synchronously, processing final response...")
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read synchronous reindex response body")
+		}
+
+		if err := json.Unmarshal(bodyBytes, &finalTaskStatus); err != nil {
+			return errors.Wrapf(err, "failed to decode synchronous reindex response: %s", string(bodyBytes))
+		}
+
+		// Check for failures in the synchronous response
+		if failures, ok := finalTaskStatus["failures"].([]interface{}); ok && len(failures) > 0 {
+			log.Printf("Reindex completed with %d failures.\n", len(failures))
+			// Output the full status including failures
+			row := types.NewRowFromMap(finalTaskStatus)
+			if err := gp.AddRow(ctx, row); err != nil {
+				return errors.Wrap(err, "failed to output final status row")
+			}
+			// Return an error to indicate partial failure
+			failureJSON, _ := json.MarshalIndent(failures, "", "  ")
+			return errors.Errorf("reindex completed with failures: %s", string(failureJSON))
+		}
+
+		log.Println("Synchronous reindex completed successfully.")
+		row := types.NewRowFromMap(finalTaskStatus)
+		if err := gp.AddRow(ctx, row); err != nil {
+			return errors.Wrap(err, "failed to output final status row")
+		}
+		reindexSuccessful = true
+
+	} else {
+		log.Println("Reindex running asynchronously, getting task ID...")
+		var initialResponse struct {
+			Task string `json:"task"`
+		}
+		if err := json.NewDecoder(res.Body).Decode(&initialResponse); err != nil {
+			return errors.Wrap(err, "failed to decode initial async reindex response")
+		}
+		taskID = initialResponse.Task
+		if taskID == "" {
+			return errors.New("failed to get task ID from async reindex response")
+		}
+		log.Printf("Reindex task started: %s. Monitoring progress (interval: %s)...\n", taskID, s.PollIntervalDuration)
+
+		// Monitor the task
+		finalTaskStatus, err = monitorReindexTask(ctx, es.Client, taskID, s.PollIntervalDuration, gp)
+		if err != nil {
+			log.Printf("Reindex task %s monitoring failed: %v\n", taskID, err)
+			// Error details should have been added to gp by monitorReindexTask
+			return errors.Wrapf(err, "reindex task %s failed", taskID)
+		}
+		log.Printf("Reindex task %s completed successfully.\n", taskID)
+		reindexSuccessful = true
+	}
+
+	// Handle Alias Swapping
+	if reindexSuccessful && s.SwapAlias != "" {
+		log.Printf("Reindex successful. Swapping alias '%s' from '%s' to '%s'...\n",
+			s.SwapAlias, s.SourceIndex, s.TargetIndex)
+		err = swapAliasAtomically(ctx, es.Client, s.SourceIndex, s.TargetIndex, s.SwapAlias)
+		if err != nil {
+			log.Printf("WARN: Failed to swap alias '%s': %v\n", s.SwapAlias, err)
+			// Don't return error here, reindex itself was successful, but log clearly.
+			// Maybe add a row to glazed output?
+			aliasErrRow := types.NewRow(
+				types.MRP("operation", "alias_swap"),
+				types.MRP("alias", s.SwapAlias),
+				types.MRP("status", "failed"),
+				types.MRP("error", err.Error()),
+			)
+			_ = gp.AddRow(ctx, aliasErrRow) // Ignore error on this warning row
+		} else {
+			log.Printf("Alias '%s' swapped successfully.\n", s.SwapAlias)
+			aliasOkRow := types.NewRow(
+				types.MRP("operation", "alias_swap"),
+				types.MRP("alias", s.SwapAlias),
+				types.MRP("status", "success"),
+			)
+			_ = gp.AddRow(ctx, aliasOkRow)
+		}
+	}
+
+	log.Println("Reindex command finished.")
+	return nil
+}
+
+// monitorReindexTask polls the Elasticsearch Tasks API for the status of a reindex task
+// and streams progress updates to the Glaze processor.
+// It returns the final task status document on success, or an error.
+func monitorReindexTask(
+	ctx context.Context,
+	es *elasticsearch.Client,
+	taskID string,
+	pollInterval time.Duration,
+	gp middlewares.Processor,
+) (map[string]interface{}, error) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("Context cancelled, stopping task monitoring for %s\n", taskID)
+			return nil, ctx.Err()
+		case <-ticker.C:
+			log.Printf("Polling task status for %s...\n", taskID)
+			res, err := es.Tasks.Get(taskID, es.Tasks.Get.WithContext(ctx))
+			if err != nil {
+				// Log transient errors but continue polling
+				log.Printf("WARN: Failed API call to get task status for %s: %v. Retrying...\n", taskID, err)
+				continue
+			}
+
+			bodyBytes, readErr := io.ReadAll(res.Body)
+			closeErr := res.Body.Close()
+			if readErr != nil {
+				log.Printf("WARN: Failed to read task status response body for %s: %v. Retrying...\n", taskID, readErr)
+				continue
+			}
+			if closeErr != nil {
+				log.Printf("WARN: Failed to close task status response body for %s: %v\n", taskID, closeErr)
+				// Continue processing the body we already read
+			}
+
+			if res.IsError() {
+				// If the task API itself returns an error (e.g., task not found after a while?)
+				log.Printf("ERROR: Task API returned error for task %s: %s\n", taskID, string(bodyBytes))
+				errData := map[string]interface{}{
+					"task_id":     taskID,
+					"status_code": res.StatusCode,
+					"error_body":  string(bodyBytes),
+					"poll_status": "api_error",
+					"completed":   false,
+					"@timestamp":  time.Now().Format(time.RFC3339),
+				}
+				_ = gp.AddRow(ctx, types.NewRowFromMap(errData))
+				return nil, errors.Errorf("task API error for %s: %s", taskID, string(bodyBytes))
+			}
+
+			// Define a struct matching the Task API response structure
+			var taskResponse struct {
+				Completed bool `json:"completed"`
+				Task      struct {
+					Node             string                 `json:"node"`
+					ID               int64                  `json:"id"`
+					Type             string                 `json:"type"`
+					Action           string                 `json:"action"`
+					Status           map[string]interface{} `json:"status"` // Keep status flexible
+					Description      string                 `json:"description"`
+					StartTimeMillis  int64                  `json:"start_time_in_millis"`
+					RunningTimeNanos int64                  `json:"running_time_in_nanos"`
+					Cancellable      bool                   `json:"cancellable"`
+				} `json:"task"`
+				Error *struct { // Pointer to handle absence of error
+					Type      string `json:"type"`
+					Reason    string `json:"reason"`
+					RootCause []struct {
+						Type   string `json:"type"`
+						Reason string `json:"reason"`
+					} `json:"root_cause"`
+				} `json:"error"`
+				Response map[string]interface{} `json:"response"` // Capture final response if needed
+			}
+
+			var fullResponseMap map[string]interface{} // For returning the final state
+
+			if err := json.Unmarshal(bodyBytes, &taskResponse); err != nil {
+				log.Printf("WARN: Failed to decode task response for %s: %v. Body: %s. Retrying...\n", taskID, err, string(bodyBytes))
+				continue // Try again next poll
+			}
+			if err := json.Unmarshal(bodyBytes, &fullResponseMap); err != nil {
+				// Less critical, just log if full map fails
+				log.Printf("WARN: Failed to unmarshal full task response map for %s: %v\n", taskID, err)
+			}
+
+			// Check if the task itself reported an error
+			if taskResponse.Error != nil {
+				errorMsg := fmt.Sprintf("reindex task %s failed: %s - %s", taskID, taskResponse.Error.Type, taskResponse.Error.Reason)
+				log.Println("ERROR:", errorMsg)
+				// Add final error status row
+				errData := map[string]interface{}{
+					"task_id":      taskID,
+					"completed":    true, // Task finished, albeit with an error
+					"poll_status":  "task_error",
+					"error_type":   taskResponse.Error.Type,
+					"error_reason": taskResponse.Error.Reason,
+					"@timestamp":   time.Now().Format(time.RFC3339),
+				}
+				if taskResponse.Task.Status != nil {
+					for k, v := range taskResponse.Task.Status {
+						errData["status_"+k] = v // Prefix status fields
+					}
+				}
+				_ = gp.AddRow(ctx, types.NewRowFromMap(errData))
+				return fullResponseMap, errors.New(errorMsg)
+			}
+
+			// Stream progress row
+			progressData := map[string]interface{}{
+				"task_id":         taskID,
+				"completed":       taskResponse.Completed,
+				"poll_status":     "in_progress",
+				"action":          taskResponse.Task.Action,
+				"node":            taskResponse.Task.Node,
+				"running_time_ns": taskResponse.Task.RunningTimeNanos,
+				"@timestamp":      time.Now().Format(time.RFC3339),
+			}
+			if taskResponse.Task.Status != nil {
+				for k, v := range taskResponse.Task.Status {
+					progressData["status_"+k] = v // Prefix status fields
+				}
+			}
+			if err := gp.AddRow(ctx, types.NewRowFromMap(progressData)); err != nil {
+				// Log error but continue monitoring if AddRow fails
+				log.Printf("WARN: Failed to add progress row to Glaze processor: %v\n", err)
+			}
+
+			// Check if completed successfully
+			if taskResponse.Completed {
+				log.Printf("Task %s completed successfully based on poll.\n", taskID)
+				// Add final success status row (optional, as progress row already shows completed=true)
+				successData := map[string]interface{}{
+					"task_id":     taskID,
+					"completed":   true,
+					"poll_status": "success",
+					"@timestamp":  time.Now().Format(time.RFC3339),
+				}
+				if taskResponse.Task.Status != nil {
+					for k, v := range taskResponse.Task.Status {
+						successData["status_"+k] = v
+					}
+				}
+				_ = gp.AddRow(ctx, types.NewRowFromMap(successData))
+				return fullResponseMap, nil // Return the full final map
+			}
+		}
+	}
+}
+
+// swapAliasAtomically removes an alias from the source index and adds it to the target index.
+func swapAliasAtomically(
+	ctx context.Context,
+	es *elasticsearch.Client,
+	sourceIndex string,
+	targetIndex string,
+	aliasName string,
+) error {
+	actions := []map[string]interface{}{
+		{
+			"remove": map[string]interface{}{
+				"index": sourceIndex,
+				"alias": aliasName,
+			},
+		},
+		{
+			"add": map[string]interface{}{
+				"index": targetIndex,
+				"alias": aliasName,
+			},
+		},
+	}
+
+	bodyMap := map[string]interface{}{"actions": actions}
+	bodyBytes, err := json.Marshal(bodyMap)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal alias actions")
+	}
+
+	res, err := es.Indices.UpdateAliases(bytes.NewReader(bodyBytes), es.Indices.UpdateAliases.WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "update aliases API call failed")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+
+	if res.IsError() {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return errors.Errorf("update aliases request failed: %s", string(bodyBytes))
+	}
+
+	return nil
+}

--- a/cmd/escuse-me/cmds/indices/stats.go
+++ b/cmd/escuse-me/cmds/indices/stats.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	esapi "github.com/elastic/go-elasticsearch/v8/esapi"
 	layers2 "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
@@ -52,10 +53,33 @@ func NewIndicesStatsCommand() (*IndicesStatsCommand, error) {
 					parameters.WithDefault("_all"),
 				),
 				parameters.NewParameterDefinition(
+					"level",
+					parameters.ParameterTypeChoice,
+					parameters.WithHelp("Level of detail for stats"),
+					parameters.WithChoices("summary", "detailed", "full"),
+					parameters.WithDefault("summary"),
+				),
+				// Hidden alias for backward compatibility
+				parameters.NewParameterDefinition(
 					"full",
 					parameters.ParameterTypeBool,
-					parameters.WithHelp("Prints the full version response instead of a summary table"),
+					parameters.WithHelp("Alias for --level=full (deprecated)"),
 					parameters.WithDefault(false),
+				),
+				parameters.NewParameterDefinition(
+					"metrics",
+					parameters.ParameterTypeChoiceList,
+					parameters.WithHelp("Specific metric groups to include (overrides/augments level). Available metrics: docs, indexing, search, segments, memory (fielddata/query_cache/request_cache memory), cache (query_cache/request_cache hits/misses), operations (refresh/flush/merges), translog"),
+					parameters.WithChoices(
+						"docs",
+						"indexing",
+						"search",
+						"segments",
+						"memory",     // groups fielddata, query_cache, request_cache memory
+						"cache",      // groups query_cache, request_cache hits/misses
+						"operations", // groups refresh, flush, merges
+						"translog",
+					),
 				),
 			),
 			cmds.WithLayersList(
@@ -68,7 +92,10 @@ func NewIndicesStatsCommand() (*IndicesStatsCommand, error) {
 
 type IndicesStatsSettings struct {
 	Index string `glazed.parameter:"index"`
-	Full  bool   `glazed.parameter:"full"`
+	Level string `glazed.parameter:"level"`
+	Full  bool   `glazed.parameter:"full"` // Kept for backward compatibility alias
+
+	Metrics []string `glazed.parameter:"metrics"`
 }
 
 func (i *IndicesStatsCommand) RunIntoGlazeProcessor(
@@ -87,19 +114,78 @@ func (i *IndicesStatsCommand) RunIntoGlazeProcessor(
 		return err
 	}
 
-	var res *esapi.Response
+	// Determine effective level (handle --full alias)
+	effectiveLevel := s.Level
 	if s.Full {
-		res, err = es.Indices.Stats(
-			es.Indices.Stats.WithIndex(s.Index),
-			es.Indices.Stats.WithLevel("indices"), // Get stats per index
-		)
-	} else {
-		res, err = es.Indices.Stats(
-			es.Indices.Stats.WithIndex(s.Index),
-			es.Indices.Stats.WithMetric("docs", "store"), // Request only necessary metrics if not full
-			es.Indices.Stats.WithLevel("indices"),        // Get stats per index
-		)
+		effectiveLevel = "full"
 	}
+
+	// Determine metrics to request from ES
+	metricsSet := map[string]bool{}
+	addMetric := func(metric ...string) {
+		for _, m := range metric {
+			metricsSet[m] = true
+		}
+	}
+
+	// Start with base metrics for summary
+	addMetric("docs", "store")
+
+	// Add metrics based on level
+	switch effectiveLevel {
+	case "detailed":
+		addMetric("indexing", "search", "segments", "refresh", "flush", "merge")
+	case "full":
+		addMetric("_all") // Request all metrics
+	}
+
+	// Add metrics explicitly requested via --metrics flag
+	for _, requestedMetric := range s.Metrics {
+		switch requestedMetric {
+		case "docs":
+			addMetric("docs")
+		case "indexing":
+			addMetric("indexing")
+		case "search":
+			addMetric("search")
+		case "segments":
+			addMetric("segments")
+		case "memory":
+			addMetric("fielddata", "query_cache", "request_cache") // Specific ES metrics
+		case "cache":
+			addMetric("query_cache", "request_cache") // Specific ES metrics
+		case "operations":
+			addMetric("refresh", "flush", "merge") // Specific ES metrics
+		case "translog":
+			addMetric("translog")
+		}
+	}
+
+	// Convert set back to slice for ES API
+	finalMetrics := []string{}
+	for m := range metricsSet {
+		if m == "_all" {
+			// If _all is present, it overrides everything else
+			finalMetrics = []string{"_all"}
+			break
+		}
+		finalMetrics = append(finalMetrics, m)
+	}
+
+	// Make the ES API call
+	var res *esapi.Response
+	// Build functional options
+	opts := []func(*esapi.IndicesStatsRequest){
+		es.Indices.Stats.WithIndex(s.Index),
+		es.Indices.Stats.WithLevel("indices"),
+	}
+	// Only add WithMetric if we are not requesting _all
+	if len(finalMetrics) > 0 && finalMetrics[0] != "_all" {
+		opts = append(opts, es.Indices.Stats.WithMetric(finalMetrics...))
+	}
+
+	res, err = es.Indices.Stats(opts...)
+
 	if err != nil {
 		return errors.Wrap(err, "failed to get index stats")
 	}
@@ -120,20 +206,36 @@ func (i *IndicesStatsCommand) RunIntoGlazeProcessor(
 			return errors.Wrap(err, "failed to unmarshal response body")
 		}
 
-		if s.Full {
+		if effectiveLevel == "full" {
 			// Output the full response as a single row
 			row := types.NewRowFromMap(statsResponse)
 			if err := gp.AddRow(ctx, row); err != nil {
 				return errors.Wrap(err, "failed to add full stats row")
 			}
 		} else {
-			// Output summarized table
+			// Output summarized/detailed/custom table
 			indices, ok := maps.Get[map[string]interface{}](statsResponse, "indices")
 			if !ok {
 				return errors.New("indices field not found or not a map in response")
 			}
 
-			for indexName, indexData_ := range indices {
+			// Determine which columns to show based on requested metrics/level
+			showMetrics := map[string]bool{}
+			for _, m := range s.Metrics {
+				showMetrics[m] = true
+			}
+			isDetailed := effectiveLevel == "detailed"
+
+			// Collect and sort index names for ordered output
+			indexNames := make([]string, 0, len(indices))
+			for name := range indices {
+				indexNames = append(indexNames, name)
+			}
+			sort.Strings(indexNames)
+
+			// Iterate over sorted names
+			for _, indexName := range indexNames {
+				indexData_ := indices[indexName] // Get data using the sorted name
 				indexData, ok := indexData_.(map[string]interface{})
 				if !ok {
 					fmt.Printf("Warning: could not parse data for index %s\n", indexName)
@@ -144,18 +246,72 @@ func (i *IndicesStatsCommand) RunIntoGlazeProcessor(
 					types.MRP("index", indexName),
 				)
 
+				// --- Always show summary fields ---
 				health, _ := maps.GetString(indexData, "health")
 				status, _ := maps.GetString(indexData, "status")
 				uuid, _ := maps.GetString(indexData, "uuid")
-				// Use GetInteger to handle potential float64 conversion from JSON numbers
 				docCount, _ := maps.GetInteger[int64](indexData, "total", "docs", "count")
 				storeSize, _ := maps.GetInteger[int64](indexData, "total", "store", "size_in_bytes")
-
 				row.Set("health", health)
 				row.Set("status", status)
 				row.Set("uuid", uuid)
 				row.Set("doc_count", docCount)
 				row.Set("store_size_bytes", storeSize)
+
+				// --- Conditionally show detailed/specific fields ---
+
+				// Helper to add a metric if requested
+				addIntMetric := func(rowKey string, keys ...string) {
+					val, _ := maps.GetInteger[int64](indexData, keys...)
+					row.Set(rowKey, val)
+				}
+				addBoolMetric := func(rowKey string, keys ...string) {
+					val, _ := maps.Get[bool](indexData, keys...)
+					row.Set(rowKey, val)
+				}
+
+				if showMetrics["docs"] || isDetailed {
+					addIntMetric("deleted_docs", "total", "docs", "deleted")
+				}
+				if showMetrics["indexing"] || isDetailed {
+					addIntMetric("indexing_ops_total", "total", "indexing", "index_total")
+					addIntMetric("indexing_time_ms", "total", "indexing", "index_time_in_millis")
+					addIntMetric("indexing_failed", "total", "indexing", "index_failed")
+					addBoolMetric("indexing_throttled", "total", "indexing", "is_throttled")
+				}
+				if showMetrics["search"] || isDetailed {
+					addIntMetric("search_query_ops_total", "total", "search", "query_total")
+					addIntMetric("search_query_time_ms", "total", "search", "query_time_in_millis")
+					addIntMetric("search_fetch_ops_total", "total", "search", "fetch_total")
+					addIntMetric("search_fetch_time_ms", "total", "search", "fetch_time_in_millis")
+				}
+				if showMetrics["segments"] || isDetailed {
+					addIntMetric("segment_count", "total", "segments", "count")
+					addIntMetric("segment_memory_bytes", "total", "segments", "memory_in_bytes")
+				}
+				if showMetrics["memory"] || isDetailed {
+					addIntMetric("fielddata_memory_bytes", "total", "fielddata", "memory_size_in_bytes")
+					addIntMetric("query_cache_memory_bytes", "total", "query_cache", "memory_size_in_bytes")
+					addIntMetric("request_cache_memory_bytes", "total", "request_cache", "memory_size_in_bytes")
+				}
+				if showMetrics["cache"] || isDetailed {
+					addIntMetric("query_cache_hit_count", "total", "query_cache", "hit_count")
+					addIntMetric("query_cache_miss_count", "total", "query_cache", "miss_count")
+					addIntMetric("request_cache_hit_count", "total", "request_cache", "hit_count")
+					addIntMetric("request_cache_miss_count", "total", "request_cache", "miss_count")
+				}
+				if showMetrics["operations"] || isDetailed {
+					addIntMetric("refresh_ops_total", "total", "refresh", "total")
+					addIntMetric("refresh_time_ms", "total", "refresh", "total_time_in_millis")
+					addIntMetric("flush_ops_total", "total", "flush", "total")
+					addIntMetric("flush_time_ms", "total", "flush", "total_time_in_millis")
+					addIntMetric("merge_ops_total", "total", "merges", "total")
+					addIntMetric("merge_time_ms", "total", "merges", "total_time_in_millis")
+				}
+				if showMetrics["translog"] {
+					addIntMetric("translog_ops_total", "total", "translog", "operations")
+					addIntMetric("translog_size_bytes", "total", "translog", "size_in_bytes")
+				}
 
 				if err := gp.AddRow(ctx, row); err != nil {
 					return errors.Wrapf(err, "failed to add row for index %s", indexName)

--- a/cmd/escuse-me/cmds/indices/stats.go
+++ b/cmd/escuse-me/cmds/indices/stats.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+
+	esapi "github.com/elastic/go-elasticsearch/v8/esapi"
 	layers2 "github.com/go-go-golems/escuse-me/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/helpers/maps"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/settings"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
-	"io"
 )
 
 type IndicesStatsCommand struct {
@@ -23,10 +26,11 @@ var _ cmds.GlazeCommand = &IndicesStatsCommand{}
 
 func NewIndicesStatsCommand() (*IndicesStatsCommand, error) {
 	glazedParameterLayer, err := settings.NewGlazedParameterLayers(
-		settings.WithOutputParameterLayerOptions(
-			layers.WithDefaults(map[string]interface{}{
-				"output": "json",
-			})))
+	// settings.WithOutputParameterLayerOptions(
+	// 	layers.WithDefaults(map[string]interface{}{
+	// 		"output": "json",
+	// 	})),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
 	}
@@ -44,13 +48,13 @@ func NewIndicesStatsCommand() (*IndicesStatsCommand, error) {
 				parameters.NewParameterDefinition(
 					"index",
 					parameters.ParameterTypeString,
-					parameters.WithHelp("The index to get stats for"),
+					parameters.WithHelp("The index pattern to get stats for"),
 					parameters.WithDefault("_all"),
 				),
 				parameters.NewParameterDefinition(
 					"full",
 					parameters.ParameterTypeBool,
-					parameters.WithHelp("Prints the full version response"),
+					parameters.WithHelp("Prints the full version response instead of a summary table"),
 					parameters.WithDefault(false),
 				),
 			),
@@ -83,34 +87,99 @@ func (i *IndicesStatsCommand) RunIntoGlazeProcessor(
 		return err
 	}
 
-	res, err := es.Indices.Stats(
-		es.Indices.Stats.WithIndex(s.Index),
-	)
+	var res *esapi.Response
+	if s.Full {
+		res, err = es.Indices.Stats(
+			es.Indices.Stats.WithIndex(s.Index),
+			es.Indices.Stats.WithLevel("indices"), // Get stats per index
+		)
+	} else {
+		res, err = es.Indices.Stats(
+			es.Indices.Stats.WithIndex(s.Index),
+			es.Indices.Stats.WithMetric("docs", "store"), // Request only necessary metrics if not full
+			es.Indices.Stats.WithLevel("indices"),        // Get stats per index
+		)
+	}
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get index stats")
 	}
 
 	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			fmt.Println(err)
-		}
+		_ = Body.Close()
 	}(res.Body)
 
-	// read all body
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return err
+	if !res.IsError() {
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		var statsResponse map[string]interface{}
+		err = json.Unmarshal(bodyBytes, &statsResponse)
+		if err != nil {
+			return errors.Wrap(err, "failed to unmarshal response body")
+		}
+
+		if s.Full {
+			// Output the full response as a single row
+			row := types.NewRowFromMap(statsResponse)
+			if err := gp.AddRow(ctx, row); err != nil {
+				return errors.Wrap(err, "failed to add full stats row")
+			}
+		} else {
+			// Output summarized table
+			indices, ok := maps.Get[map[string]interface{}](statsResponse, "indices")
+			if !ok {
+				return errors.New("indices field not found or not a map in response")
+			}
+
+			for indexName, indexData_ := range indices {
+				indexData, ok := indexData_.(map[string]interface{})
+				if !ok {
+					fmt.Printf("Warning: could not parse data for index %s\n", indexName)
+					continue
+				}
+
+				row := types.NewRow(
+					types.MRP("index", indexName),
+				)
+
+				health, _ := maps.GetString(indexData, "health")
+				status, _ := maps.GetString(indexData, "status")
+				uuid, _ := maps.GetString(indexData, "uuid")
+				// Use GetInteger to handle potential float64 conversion from JSON numbers
+				docCount, _ := maps.GetInteger[int64](indexData, "total", "docs", "count")
+				storeSize, _ := maps.GetInteger[int64](indexData, "total", "store", "size_in_bytes")
+
+				row.Set("health", health)
+				row.Set("status", status)
+				row.Set("uuid", uuid)
+				row.Set("doc_count", docCount)
+				row.Set("store_size_bytes", storeSize)
+
+				if err := gp.AddRow(ctx, row); err != nil {
+					return errors.Wrapf(err, "failed to add row for index %s", indexName)
+				}
+			}
+		}
+	} else {
+		// Handle ES error response
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read error response body")
+		}
+		// Try to parse as standard ES error, otherwise return raw body
+		var esError map[string]interface{}
+		err = json.Unmarshal(bodyBytes, &esError)
+		if err == nil {
+			row := types.NewRowFromMap(esError)
+			if err := gp.AddRow(ctx, row); err != nil {
+				return errors.Wrap(err, "failed to add error row")
+			}
+		} else {
+			return errors.Errorf("Elasticsearch error: %s", string(bodyBytes))
+		}
 	}
 
-	body_ := types.NewRow()
-	err = json.Unmarshal(body, &body_)
-	if err != nil {
-		return err
-	}
-	err = gp.AddRow(ctx, body_)
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/cmd/escuse-me/cmds/indices/update-aliases.go
+++ b/cmd/escuse-me/cmds/indices/update-aliases.go
@@ -48,7 +48,7 @@ func NewIndicesUpdateAliasesCommand() (*IndicesUpdateAliasesCommand, error) {
 			cmds.WithLong(`Allows performing one or more alias actions (add, remove) in a single atomic operation. Define actions in a JSON/YAML body.`),
 			cmds.WithFlags(
 				parameters.NewParameterDefinition(
-					"body",
+					"actions",
 					parameters.ParameterTypeObjectFromFile, // Body containing actions is required
 					parameters.WithHelp("JSON/YAML object defining the 'actions' array (add/remove operations)"),
 					parameters.WithRequired(true),
@@ -72,8 +72,8 @@ func NewIndicesUpdateAliasesCommand() (*IndicesUpdateAliasesCommand, error) {
 }
 
 type IndicesUpdateAliasesSettings struct {
-	// Body must contain the 'actions' for the API call
-	Body          map[string]interface{} `glazed.parameter:"body"`
+	// Actions must contain the 'actions' for the API call
+	Actions       map[string]interface{} `glazed.parameter:"actions"`
 	MasterTimeout time.Duration          `glazed.parameter:"master_timeout"`
 	Timeout       time.Duration          `glazed.parameter:"timeout"`
 }
@@ -94,13 +94,13 @@ func (c *IndicesUpdateAliasesCommand) Run(
 	}
 
 	log.Debug().
-		Interface("body", s.Body).
+		Interface("body", s.Actions).
 		Dur("master_timeout", s.MasterTimeout).
 		Dur("timeout", s.Timeout).
 		Msg("Updating aliases")
 
 	// Marshal the body which contains the actions
-	bodyBytes, err := json.Marshal(s.Body)
+	bodyBytes, err := json.Marshal(s.Actions)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal request body")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.17.0
 	github.com/go-go-golems/clay v0.1.38
 	github.com/go-go-golems/geppetto v0.4.47
-	github.com/go-go-golems/glazed v0.5.46
+	github.com/go-go-golems/glazed v0.5.47
 	github.com/go-go-golems/go-emrichen v0.0.7
 	github.com/go-go-golems/parka v0.5.25
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/go-go-golems/clay v0.1.38 h1:z53a8CsylLkFo/vexhuZQhcEB5XARPgvCpdPSPc1
 github.com/go-go-golems/clay v0.1.38/go.mod h1:iu+s1/Ng3r6FUKXI4NN0/P/E45MlpL3qkglvKhR7u+w=
 github.com/go-go-golems/geppetto v0.4.47 h1:+JGLUZJZEzGfb+MiGcceVv6y5Ye6P3/E/8nYp4Hi4PU=
 github.com/go-go-golems/geppetto v0.4.47/go.mod h1:Nlid0zl6WqEeUdO8SY9mIxOpXQD1x+BfuG6cUBsC6d4=
-github.com/go-go-golems/glazed v0.5.46 h1:Trmil2uTS/yFdclW8jl0kic/vTaJQelEHq9xEtefmPc=
-github.com/go-go-golems/glazed v0.5.46/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
+github.com/go-go-golems/glazed v0.5.47 h1:e6nXWO4/j/odHfyp65A+KOGVE3U6ooLE6fbElxn1DrU=
+github.com/go-go-golems/glazed v0.5.47/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
 github.com/go-go-golems/go-emrichen v0.0.7 h1:RSJajEihqieIWEo/X63DBY5N5tDl9JuZrFtxP2zImic=
 github.com/go-go-golems/go-emrichen v0.0.7/go.mod h1:2P4dTvCe7ystMW7mR2Wu58XXw5mF/0lH8lm6APYFpYQ=
 github.com/go-go-golems/parka v0.5.25 h1:J6Qt9Ou+ZFIMuF6zERx8x0fXxxeTLbjAzqxtAE3dP+U=

--- a/pkg/doc/topics/07-reindexing.md
+++ b/pkg/doc/topics/07-reindexing.md
@@ -1,0 +1,266 @@
+---
+Title: Reindexing Elasticsearch Data with escuse-me
+Slug: reindexing
+Short: Guide to using the reindex command for copying, transforming, and managing index data.
+Topics:
+  - elasticsearch
+  - indices
+  - reindexing
+  - tasks
+  - aliases
+Commands:
+  - indices reindex
+Flags:
+  - source-index
+  - target-index
+  - query
+  - script
+  - pipeline
+  - batch-size
+  - slices
+  - requests-per-second
+  - wait-for-completion
+  - poll-interval
+  - create-target
+  - target-settings
+  - target-mappings
+  - swap-alias
+  - timeout
+  - request-timeout
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+# Reindexing Elasticsearch Data with escuse-me
+
+This document explains how to use the `escuse-me indices reindex` command to copy documents between Elasticsearch indices. This process is crucial for managing your data effectively, especially when you need to apply changes or restructure your indices.
+
+## What is Reindexing?
+
+Reindexing in Elasticsearch is essentially the process of copying documents from an existing index (the "source") into another index (the "destination" or "target"). Think of it like making a processed copy of your data from one table or database to another.
+
+**Why is it necessary?** Many core aspects of an Elasticsearch index, such as its fundamental structure (mappings, like field types) or certain performance settings (like the number of primary shards), cannot be changed after the index is created. If you need to make such changes – perhaps you decided a text field should have been analyzed differently, or you want to optimize shard allocation – you can't modify the existing index directly. Instead, you create a _new_ index with the desired structure and then copy the data from the old index into the new one using reindexing.
+
+Common scenarios requiring reindexing include:
+
+- **Changing Mappings or Settings:** The most frequent reason. You might need to change a field's type (e.g., from `text` to `keyword`), add a new analyzer for better search relevance, or adjust the number of shards (though this requires more advanced techniques usually involving reindexing into a new index with the desired shard count).
+- **Upgrading Indices:** When moving to a new major version of Elasticsearch, the underlying data format might change, requiring you to reindex data from the old version's indices into new indices compatible with the upgraded version.
+- **Consolidating Indices:** You might have data spread across multiple indices (e.g., daily logs) and want to combine them into a single, larger index for easier querying or retention management.
+- **Filtering or Transforming Data:** You can use reindexing to create a new index that contains only a subset of the original data (e.g., only active users) or where the documents have been modified or enriched during the copy process (e.g., adding a new field, renaming an existing one).
+
+The `escuse-me indices reindex` command provides a user-friendly interface to Elasticsearch's built-in `_reindex` API. It simplifies the process by handling API calls, optionally monitoring the long-running reindex task, providing progress updates, and allowing for actions like swapping index aliases upon completion.
+
+## The `reindex` Command
+
+The primary command for this functionality is `escuse-me indices reindex`.
+
+### Core Functionality
+
+At its simplest, the command takes a `--source-index` and a `--target-index` and tells Elasticsearch to start copying documents. A key feature of the `escuse-me` command is its default behavior: it runs the reindex **asynchronously**. This means the command tells Elasticsearch to start the job in the background and then immediately begins monitoring its progress.
+
+Elasticsearch manages long-running operations like reindexing as "Tasks". The `escuse-me` command gets the ID of this background task and periodically asks Elasticsearch (using the Tasks API) for status updates. These updates are then displayed, typically as streaming output (which you can format as tables, JSON, etc., using standard `glazed` flags like `-o table --output-mode stream`). This gives you real-time insight into how the reindex is progressing without requiring the command itself to stay connected for the entire duration (which could be hours for large indices).
+
+```bash
+# Basic asynchronous reindex (command monitors progress in the background)
+escuse-me indices reindex --source-index old-logs --target-index new-logs
+
+# View progress as a nicely formatted table
+# The --output-mode stream is important for seeing updates as they happen
+escuse-me indices reindex --source-index old-logs --target-index new-logs -o table --output-mode stream
+```
+
+This is different from the `escuse-me indices clone` command, which uses filesystem-level hard links (where possible) for a near-instantaneous copy but _cannot_ change mappings or filter data during the process. Reindexing reads each document and writes it again, making it more resource-intensive but far more flexible.
+
+### Common Use Cases & Examples
+
+Let's explore how to use the `reindex` command for various common tasks.
+
+#### 1. Simple Copy to Existing Index
+
+This is the most basic scenario: you have an existing `target-index` (perhaps created manually beforehand) and want to populate it with data from `source-index`.
+
+```bash
+# Assumes 'my-target-backup' index already exists
+escuse-me indices reindex \
+  --source-index my-source-data \
+  --target-index my-target-backup
+```
+
+#### 2. Create Target Index During Reindex
+
+Often, you reindex because you need a _new_ index structure. The `--create-target` flag lets you create this new index as part of the reindex command itself. You'll typically provide the desired **settings** (like shard/replica counts) and **mappings** (field definitions) in JSON or YAML files.
+
+```bash
+# settings.json: Controls physical aspects like shards and replicas
+echo '{"index": {"number_of_shards": 3, "number_of_replicas": 1}}' > settings.json
+
+# mappings.json: Defines fields and their types/analyzers
+echo '{"properties": {"message": {"type": "text", "analyzer": "english"}, "timestamp": {"type": "date"}}}' > mappings.json
+
+# Reindex from 'old-index' and create 'newly-structured-index' on the fly
+escuse-me indices reindex \
+  --source-index old-index \
+  --target-index newly-structured-index \
+  --create-target \
+  --target-settings settings.json \
+  --target-mappings mappings.json
+```
+
+_Note: Using `--create-target` requires you to provide the structure via `--target-settings` and/or `--target-mappings`._
+
+#### 3. Filtering Documents
+
+Sometimes you only want a subset of the original data. You can provide an Elasticsearch query (in a file) using the `--query` flag. Only documents matching this query will be copied.
+
+```bash
+# query.json: Contains the filter logic
+echo '{"query": {"term": {"status": "active"}}}' > query.json
+
+# Copy only active users to the new index
+escuse-me indices reindex \
+  --source-index all-users \
+  --target-index active-users \
+  --query query.json
+```
+
+#### 4. Transforming Documents with a Script
+
+Reindexing allows you to modify documents as they are copied. The `--script` flag takes a script (usually written in Elasticsearch's "Painless" language) that runs for each document. You can add, remove, or modify fields.
+
+```bash
+# transform.json: Contains the script logic
+cat <<EOF > transform.json
+{
+  "source": "ctx._source.new_field = ctx._source.remove('old_field'); ctx._source.reindexed_at = params.now;",
+  "lang": "painless",
+  "params": {
+    "now": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  }
+}
+EOF
+# This script:
+# 1. Removes 'old_field' and puts its value into 'new_field'.
+# 2. Adds a 'reindexed_at' field using a timestamp passed as a parameter.
+
+escuse-me indices reindex \
+  --source-index legacy-data \
+  --target-index modern-data \
+  --script transform.json
+```
+
+#### 5. Transforming Documents with an Ingest Pipeline
+
+For more complex or reusable transformations (like enriching data with lookups, parsing logs, etc.), Elasticsearch offers "Ingest Pipelines". If you have defined such a pipeline in your cluster, you can tell reindex to use it via the `--pipeline` flag.
+
+```bash
+# Assumes a pipeline named 'my-enrichment-pipeline' is already defined in Elasticsearch
+escuse-me indices reindex \
+  --source-index raw-logs \
+  --target-index enriched-logs \
+  --pipeline my-enrichment-pipeline
+```
+
+#### 6. Controlling Performance
+
+Reindexing large amounts of data can be resource-intensive. These flags help manage performance:
+
+- `--batch-size`: How many documents Elasticsearch reads from the source in one go. Larger batches can be more efficient but use more memory.
+- `--slices`: Splits the read operation into multiple parallel "slices" (like threads) for faster processing on clusters with sufficient resources. `slices > 1` enables parallelism.
+- `--requests-per-second`: Throttles how many write requests are sent to the target index per second. Useful to prevent overwhelming the cluster. `-1` means no throttling.
+
+```bash
+# Example: Faster processing with larger batches and parallelism, but throttled writes
+escuse-me indices reindex \
+  --source-index large-source \
+  --target-index large-target \
+  --batch-size 5000 \
+  --slices 4 \
+  --requests-per-second 500 # Limit writes to 500 docs/sec
+```
+
+#### 7. Running Synchronously
+
+While async monitoring is often preferred for large jobs, you can make the command wait until the entire reindex operation is finished using `--wait-for-completion`. The command will block until Elasticsearch reports completion (or failure) and then output the final summary.
+
+```bash
+# Use this for smaller indices or when scripting reindex as part of a larger process
+escuse-me indices reindex \
+  --source-index small-config \
+  --target-index updated-config \
+  --wait-for-completion
+```
+
+#### 8. Atomic Alias Swap
+
+An **alias** in Elasticsearch is like a symbolic link or pointer to one or more indices. Applications often query an alias (e.g., `live-data`) instead of a specific index name (e.g., `data-v1`). This allows you to switch the underlying index without changing your application code.
+
+The `--swap-alias` flag leverages this for zero-downtime updates. If the reindex completes successfully, the command will atomically perform two actions: remove the specified alias from the `--source-index` and add it to the `--target-index`. Your application querying the alias will seamlessly start hitting the newly reindexed data.
+
+```bash
+# 1. Reindex data from data-v1 to data-v2
+# 2. If successful, atomically switch the 'live-data' alias to point to data-v2
+escuse-me indices reindex \
+  --source-index data-v1 \
+  --target-index data-v2 \
+  --create-target --target-settings settings.json --target-mappings mappings.json \
+  --swap-alias live-data
+```
+
+### Monitoring Progress
+
+In the default asynchronous mode, you'll see status updates containing fields like:
+
+- `task_id`: The identifier for the background reindex job in Elasticsearch.
+- `completed`: `true` if the task finished (successfully or with errors), `false` otherwise.
+- `poll_status`: Status reported by `escuse-me` monitor (`in_progress`, `success`, `task_error`, `api_error`).
+- `running_time_ns`: How long the task has been running.
+- `status_total`: The total number of documents expected to be processed.
+- `status_created`, `status_updated`, `status_deleted`: Counts of documents processed.
+- `status_batches`: Number of batches processed so far.
+- `status_version_conflicts`: Number of documents skipped due to version conflicts (see `op_type: "create"` note below).
+- `status_noops`: Documents that didn't require any change.
+- `final_*`: Details from the final task result upon successful completion.
+- `error_*`: Details if the task failed.
+- `@timestamp`: When the status update was generated.
+
+Use glazed flags (`-o table --output-mode stream`, `-o json`, etc.) to control the output format.
+
+### Options Overview
+
+**Source & Target:**
+
+- `--source-index` (required): Index/indices to read from.
+- `--target-index` (required): Index to write to.
+- `--create-target`: Create the target index if absent.
+- `--target-settings`: Structure (shards, replicas) for the new index (JSON/YAML file).
+- `--target-mappings`: Field definitions for the new index (JSON/YAML file).
+
+**Filtering & Transformation:**
+
+- `--query`: Filter documents using an Elasticsearch query (JSON/YAML file).
+- `--script`: Modify documents using a script (JSON/YAML file containing `source`, `lang`, `params`).
+- `--pipeline`: Apply a pre-defined Elasticsearch ingest pipeline.
+
+**Performance & Throttling:**
+
+- `--batch-size` (default: 1000): Number of docs per read batch.
+- `--slices` (default: 1): Enable parallel reads (`>1`).
+- `--requests-per-second` (default: -1): Throttle writes (-1 = unlimited).
+
+**Control Flow & Monitoring:**
+
+- `--wait-for-completion` (default: false): Run synchronously (blocks until done).
+- `--poll-interval` (default: 5s): Check frequency for async monitoring.
+- `--timeout` (default: 1m): Timeout for the overall coordination.
+
+**Alias Management:**
+
+- `--swap-alias`: Alias name to atomically switch from source to target upon success.
+
+### Important Notes
+
+- **Resource Intensive:** Reindexing reads and writes data, unlike `clone`. It can heavily load your cluster (CPU, I/O, memory). Monitor your cluster, especially during large operations, and consider using `--requests-per-second` throttling.
+- **`op_type: "create"`:** By default, `escuse-me indices reindex` tells Elasticsearch to only _create_ documents in the target index. If a document with the same ID already exists there, it causes a "version conflict" and the document is skipped (counted in `status_version_conflicts`). This is often the safest approach to avoid accidental overwrites. If you intend to overwrite or update existing documents in the target, you would need to use the Elasticsearch API directly with a different `op_type` or potentially use an update script.
+- **Failures:** Individual documents might fail during reindexing (e.g., due to script errors or mapping conflicts). The task might complete with failures reported. Check the final status or error messages carefully. The command might return an error status even if _some_ documents were successfully processed.

--- a/pkg/doc/tutorials/01-reindexing.md
+++ b/pkg/doc/tutorials/01-reindexing.md
@@ -1,0 +1,232 @@
+# Tutorial: Reindexing with Mapping Changes and Alias Swapping using escuse-me
+
+This tutorial demonstrates a common Elasticsearch workflow: changing the mapping of an existing field, which requires creating a new index and reindexing the data. We will use an alias to ensure applications querying the data experience zero downtime during the switch.
+
+**Scenario:**
+
+We have an index (`my-data-v1`) containing documents with a `metadata` field mapped as an `object`. We realize we need this field to be analyzed as `text` instead. Since existing field mappings cannot be changed, we'll:
+
+1.  Create the initial index (`my-data-v1`) with the `object` mapping.
+2.  (Assume data is indexed into `my-data-v1`).
+3.  Create an alias (`my-data-alias`) pointing to `my-data-v1`.
+4.  Define and create a new index (`my-data-v2`) with the `metadata` field mapped as `text`.
+5.  Reindex the data from `my-data-v1` to `my-data-v2`.
+6.  Atomically update the alias (`my-data-alias`) to point to the new index (`my-data-v2`).
+
+**Prerequisites:**
+
+- `escuse-me` CLI installed and configured to connect to your Elasticsearch cluster.
+- Familiarity with basic JSON and shell commands.
+
+---
+
+## Step 1: Create the Initial Index (v1)
+
+First, define the mappings for our initial index, `my-data-v1`. Note the `metadata` field is of type `object`.
+
+**`mappings-v1.json`:**
+
+```json
+{
+  "properties": {
+    "id": { "type": "integer" },
+    "user": { "type": "keyword" },
+    "timestamp": { "type": "date" },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}
+```
+
+Now, create the index using the `create` command:
+
+```bash
+escuse-me indices create \
+  --index my-data-v1 \
+  --mappings mappings-v1.json
+```
+
+You should see confirmation that the index was created.
+
+---
+
+## Step 2: Index Sample Data
+
+This step involves populating `my-data-v1` with documents using the `bulk-index` command. This command reads JSON objects from one or more files and sends them to the specified index using Elasticsearch's bulk API.
+
+First, create a file named `sample-data.jsonl` (using `.jsonl` for JSON Lines format, where each line is a valid JSON object) with the documents you want to index:
+
+**`sample-data.jsonl`:**
+
+```json
+{ "id": 1, "user": "alice", "timestamp": "2023-10-26T10:00:00Z", "metadata": {"source": "web", "session": "xyz"} }
+{ "id": 2, "user": "bob", "timestamp": "2023-10-26T10:05:00Z", "metadata": {"source": "api", "version": 2} }
+```
+
+Now, use the `bulk-index` command to index the documents from this file into `my-data-v1`:
+
+```bash
+escuse-me documents bulk-index \\
+  --index my-data-v1 \\
+  --files sample-data.jsonl
+```
+
+The command will output the results of the bulk operation, indicating successful indexing or any errors.
+
+**Optional: Inspect Indexed Data with `dump`**
+
+You can use the `indices dump` command to view the documents you just indexed. This command uses the efficient Point-in-Time (PIT) API. By default, it outputs using Glazed, so you can format it as a table, JSON, YAML, or JSON Lines (often useful for programmatic processing).
+
+```bash
+# Dump documents from my-data-v1 as JSON Lines
+escuse-me indices dump --index my-data-v1 -o jsonl
+
+# Or view as a table (adjust fields as needed)
+# escuse-me indices dump --index my-data-v1 -o table --fields _id,_source.*
+```
+
+---
+
+## Step 3: Create an Alias for the Index
+
+Aliases provide a stable endpoint for applications. Create an alias `my-data-alias` pointing to our current index `my-data-v1`.
+
+```bash
+escuse-me indices create-alias \
+  --index my-data-v1 \
+  --name my-data-alias
+```
+
+You can verify the alias was created:
+
+```bash
+# Use glazed flags for better table output if available, or just list all aliases
+escuse-me indices aliases
+# Look for my-data-alias pointing to my-data-v1 in the output
+```
+
+This should show `my-data-v1` associated with `my-data-alias`.
+
+---
+
+## Step 4: Define and Create the New Index (v2)
+
+Now, define the mappings for our target index, `my-data-v2`. The key change is `metadata` is now type `text`.
+
+**`mappings-v2.json`:**
+
+```json
+{
+  "properties": {
+    "id": { "type": "integer" },
+    "user": { "type": "keyword" },
+    "timestamp": { "type": "date" },
+    "metadata": {
+      "type": "text",
+      "analyzer": "standard"
+    }
+  }
+}
+```
+
+_Note: We switched type to `text` and specified an analyzer._
+
+Create the `my-data-v2` index:
+
+```bash
+escuse-me indices create \
+  --index my-data-v2 \
+  --mappings mappings-v2.json
+```
+
+---
+
+## Step 5: Reindex Data from v1 to v2
+
+Copy the documents from the old index to the new one using the `reindex` command. Because the `metadata` field is changing from `object` to `text`, Elasticsearch cannot automatically convert it. We need to provide a simple script to tell Elasticsearch _how_ to handle this conversion during reindexing.
+
+First, create a file named `transform-metadata.json` with the following script:
+
+**`transform-metadata.json`:**
+
+```json
+{
+  "source": "ctx._source.metadata = ctx._source.metadata.toString()",
+  "lang": "painless"
+}
+```
+
+This script uses Elasticsearch's Painless scripting language. For each document (`ctx._source`), it takes the existing `metadata` field and converts its value to a string representation before indexing it into the new `text` field in `my-data-v2`.
+
+Now, run the reindex command, referencing this script:
+
+We use `--wait-for-completion` here to simplify the tutorial flow, making the command block until the reindex is done. For large indices, you would typically omit this and monitor the progress using the default asynchronous behavior (see `escuse-me indices reindex --help` or the Reindexing documentation topic).
+
+```bash
+escuse-me indices reindex \
+  --source-index my-data-v1 \
+  --target-index my-data-v2 \
+  --script transform-metadata.json \
+  --wait-for-completion
+```
+
+The output will show the result, including counts of created documents.
+
+**Optional: Inspect Reindexed Data**
+
+You can again use `indices dump` to check the contents of the new index:
+
+```bash
+escuse-me indices dump --index my-data-v2 -o jsonl
+```
+
+You should see the `metadata` field now contains the stringified version of the original object.
+
+---
+
+## Step 6: Atomically Update the Alias
+
+This is the crucial step for zero downtime. We want to switch `my-data-alias` from `my-data-v1` to `my-data-v2` in a single, atomic operation. The `update-aliases` command requires a JSON structure describing the actions.
+
+**`alias-actions.json`:**
+
+```json
+{
+  "actions": [
+    { "remove": { "index": "my-data-v1", "alias": "my-data-alias" } },
+    { "add": { "index": "my-data-v2", "alias": "my-data-alias" } }
+  ]
+}
+```
+
+Execute the update:
+
+```bash
+escuse-me indices update-aliases --actions alias-actions.json
+```
+
+Verify the alias switch:
+
+```bash
+escuse-me indices aliases
+# Look for my-data-alias now pointing only to my-data-v2 in the output
+```
+
+This should now show `my-data-alias` pointing only to `my-data-v2`. Applications querying `my-data-alias` are now seamlessly using the data in the new index with the updated mapping.
+
+---
+
+## Conclusion
+
+You have successfully:
+
+- Created an index with specific mappings.
+- Created an alias for it.
+- Created a new index with modified mappings.
+- Reindexed the data from the old index to the new one.
+- Atomically switched the alias to point to the new index.
+
+This pattern is fundamental for managing evolving Elasticsearch schemas without disrupting applications. You can now safely consider deleting the old `my-data-v1` index if it's no longer needed, using `escuse-me indices delete --index my-data-v1`.
+
+For more advanced reindexing options like scripting, filtering, throttling, and asynchronous monitoring, refer to the documentation for the `escuse-me indices reindex` command (potentially available via `escuse-me indices reindex --help` or in documentation files like `escuse-me/pkg/doc/topics/07-reindexing.md`).

--- a/pkg/doc/tutorials/01-reindexing.md
+++ b/pkg/doc/tutorials/01-reindexing.md
@@ -1,3 +1,40 @@
+---
+Title: Reindexing with Mapping Changes and Alias Swapping
+Slug: reindexing-tutorial
+Short: Tutorial on reindexing Elasticsearch data with mapping changes and zero downtime using aliases.
+Topics:
+  - elasticsearch
+  - reindexing
+  - aliases
+  - mapping
+  - zero-downtime
+Commands:
+  - indices create
+  - documents bulk-index
+  - indices dump
+  - indices create-alias
+  - indices aliases
+  - indices reindex
+  - indices update-aliases
+  - indices delete
+Flags:
+  - --index
+  - --mappings
+  - --files
+  - -o
+  - --fields
+  - --name
+  - --source-index
+  - --target-index
+  - --script
+  - --wait-for-completion
+  - --actions
+IsTopLevel: false
+IsTemplate: false
+ShowPerDefault: true
+SectionType: Tutorial
+---
+
 # Tutorial: Reindexing with Mapping Changes and Alias Swapping using escuse-me
 
 This tutorial demonstrates a common Elasticsearch workflow: changing the mapping of an existing field, which requires creating a new index and reindexing the data. We will use an alias to ensure applications querying the data experience zero downtime during the switch.

--- a/tests/tutorials/01-reindexing/alias-actions.json
+++ b/tests/tutorials/01-reindexing/alias-actions.json
@@ -1,0 +1,6 @@
+{
+  "actions": [
+    { "remove": { "index": "my-data-v1", "alias": "my-data-alias" } },
+    { "add": { "index": "my-data-v2", "alias": "my-data-alias" } }
+  ]
+} 

--- a/tests/tutorials/01-reindexing/mappings-v1.json
+++ b/tests/tutorials/01-reindexing/mappings-v1.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "id": { "type": "integer" },
+    "user": { "type": "keyword" },
+    "timestamp": { "type": "date" },
+    "metadata": {
+      "type": "object"
+    }
+  }
+} 

--- a/tests/tutorials/01-reindexing/mappings-v2.json
+++ b/tests/tutorials/01-reindexing/mappings-v2.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "id": { "type": "integer" },
+    "user": { "type": "keyword" },
+    "timestamp": { "type": "date" },
+    "metadata": {
+      "type": "text",
+      "analyzer": "standard"
+    }
+  }
+} 

--- a/tests/tutorials/01-reindexing/sample-data.jsonl
+++ b/tests/tutorials/01-reindexing/sample-data.jsonl
@@ -1,0 +1,2 @@
+{ "id": 1, "user": "alice", "timestamp": "2023-10-26T10:00:00Z", "metadata": {"source": "web", "session": "xyz"} }
+{ "id": 2, "user": "bob", "timestamp": "2023-10-26T10:05:00Z", "metadata": {"source": "api", "version": 2} } 

--- a/tests/tutorials/01-reindexing/transform-metadata.json
+++ b/tests/tutorials/01-reindexing/transform-metadata.json
@@ -1,0 +1,4 @@
+{
+  "source": "ctx._source.metadata = ctx._source.metadata.toString()",
+  "lang": "painless"
+} 

--- a/ttmp/2025-04-10/01-ilm-command-design.md
+++ b/ttmp/2025-04-10/01-ilm-command-design.md
@@ -1,0 +1,119 @@
+# Design Document: `escuse-me ilm` Subcommands
+
+**Date:** 2025-04-10
+
+## 1. Introduction and Context
+
+Elasticsearch's Index Lifecycle Management (ILM) is a crucial feature for managing time-series data (like logs, metrics, events) efficiently. As indices grow over time, ILM allows automating tasks such as rolling over to new indices, optimizing older indices (shrinking, force merging), moving data between hardware tiers (hot/warm/cold), and eventually deleting data based on retention policies.
+
+Currently, managing ILM often requires direct interaction with the Elasticsearch REST API or using the Kibana UI. The goal of adding `ilm` subcommands to `escuse-me` is to provide a convenient, scriptable, and consistent command-line interface for common ILM tasks, integrating seamlessly with the existing `escuse-me` framework (including connection handling via layers and output formatting via Glazed).
+
+This document outlines the proposed commands and provides context for a developer to implement them.
+
+## 2. ILM Overview (Elasticsearch 8.x)
+
+- **Policies:** The core of ILM. A policy defines a set of phases and actions.
+- **Phases:** Represent stages in an index's life (e.g., `hot`, `warm`, `cold`, `frozen`, `delete`). An index moves sequentially through the phases defined in its policy.
+- **Actions:** Operations performed within a phase (e.g., `rollover`, `shrink`, `forcemerge`, `freeze`, `set_priority`, `delete`).
+- **Triggers:** Conditions that cause an action to execute or a phase transition to occur (e.g., `min_age`, `min_size`, `min_docs`).
+- **Application:** ILM policies are typically applied to _new_ indices via index templates. An index template matching a new index can specify the `index.lifecycle.name` (the policy to apply) and often `index.lifecycle.rollover_alias` (needed for the `rollover` action).
+- **Management:** Can be managed via Kibana UI or the `/_ilm` REST API endpoints.
+
+**Key Resources:**
+
+- [Elasticsearch ILM Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html)
+- [Logz.io ILM Blog Post](https://logz.io/blog/managing-elasticsearch-indices/)
+
+## 3. Proposed `escuse-me ilm` Commands
+
+This section details the proposed subcommands under `escuse-me ilm`.
+
+### 3.1 Policy Management
+
+**3.1.1 `escuse-me ilm list-policies`**
+
+- **Purpose:** List all defined ILM policies in the cluster.
+- **CLI:** `escuse-me ilm list-policies [glazed flags]`
+- **ES API:** `GET /_ilm/policy`
+- **Output:** Table (via Glazed) showing policy names and potentially version/modified date.
+
+**3.1.2 `escuse-me ilm get-policy`**
+
+- **Purpose:** Show the full JSON definition of one or more specific ILM policies.
+- **CLI:** `escuse-me ilm get-policy <policy_name> [policy_name...] [glazed flags]`
+- **ES API:** `GET /_ilm/policy/<policy_name>` (potentially multiple calls or `GET /_ilm/policy/<policy1>,<policy2>...`)
+- **Output:** JSON output (possibly formatted via Glazed) of the policy definition(s).
+
+**3.1.3 `escuse-me ilm create-policy`**
+
+- **Purpose:** Create a new ILM policy or update an existing one from a JSON definition.
+- **CLI:** `escuse-me ilm create-policy --name <policy_name> --file <policy.json>`
+- **ES API:** `PUT /_ilm/policy/<policy_name>` (with the JSON content from the file as the request body)
+- **Output:** Confirmation message.
+
+**3.1.4 `escuse-me ilm delete-policy`**
+
+- **Purpose:** Delete one or more ILM policies.
+- **CLI:** `escuse-me ilm delete-policy <policy_name> [policy_name...]`
+- **ES API:** `DELETE /_ilm/policy/<policy_name>` (one call per policy)
+- **Output:** Confirmation message(s).
+
+**3.1.5 `escuse-me ilm validate-policy` (Optional/Advanced)**
+
+- **Purpose:** Perform client-side validation of a policy JSON file _before_ sending it to Elasticsearch. Could check for basic structure, known required fields, etc.
+- **CLI:** `escuse-me ilm validate-policy --file <policy.json>`
+- **ES API:** None (client-side logic).
+- **Output:** Validation success message or list of errors/warnings.
+
+### 3.2 Index & Status Management
+
+**3.2.1 `escuse-me ilm explain`**
+
+- **Purpose:** Show the detailed ILM status for one or more indices.
+- **CLI:** `escuse-me ilm explain <index_name> [index_name...] [glazed flags]`
+- **ES API:** `GET /<index_name>/_ilm/explain` (one call per index, potentially parallelized)
+- **Output:** Table (via Glazed) showing index name, managed status, policy, phase, action, step, step info/error.
+
+**3.2.2 `escuse-me ilm list-managed-indices` (Advanced)**
+
+- **Purpose:** List indices that are currently managed by ILM, optionally filtering by policy.
+- **CLI:** `escuse-me ilm list-managed-indices [--policy <policy_name>] [glazed flags]`
+- **ES API:** Might require `GET /_cat/indices?h=index,settings.index.lifecycle.name` and filtering, or iterating `GET */_ilm/explain` and filtering (potentially slow).
+- **Output:** Table (via Glazed) of index names managed by ILM (and their policy if not filtered).
+
+**3.2.3 `escuse-me ilm retry`**
+
+- **Purpose:** Force ILM to retry the current step for an index where ILM processing has failed or stalled.
+- **CLI:** `escuse-me ilm retry <index_name> [index_name...]`
+- **ES API:** `POST /<index_name>/_ilm/retry` (one call per index)
+- **Output:** Confirmation message(s).
+
+### 3.3 Template & Rollover Helpers
+
+**3.3.1 `escuse-me templates add-ilm`**
+
+- **Purpose:** Add or update ILM configuration (`index.lifecycle.name`, `index.lifecycle.rollover_alias`) within an _existing_ index template's settings.
+- **CLI:** `escuse-me templates add-ilm --template <template_name> --policy <policy_name> --rollover-alias <alias_name>`
+- **ES API:**
+  1.  `GET /_index_template/<template_name>`
+  2.  Modify the `settings` section of the template JSON.
+  3.  `PUT /_index_template/<template_name>` (with the modified template definition)
+- **Output:** Confirmation message.
+- **Note:** This should probably live under an `escuse-me templates` subcommand group rather than `ilm`.
+
+**3.3.2 `escuse-me ilm force-rollover`**
+
+- **Purpose:** Manually trigger the rollover action for an alias managed by ILM.
+- **CLI:** `escuse-me ilm force-rollover <rollover_alias> [--dry-run] [--conditions <json_conditions>]`
+- **ES API:** `POST /<rollover_alias>/_rollover` (potentially with conditions in the body)
+- **Output:** Result of the rollover attempt.
+
+## 4. Implementation Notes
+
+- **Structure:** Create a new command group under `escuse-me/cmd/escuse-me/cmds/ilm/`. Each command will be a separate Go file implementing the `cobra.Command` and likely the `glazed.GlazeCommand` interface.
+- **ES Client:** Utilize the existing `es_layers.NewESClientFromParsedLayers` to get an Elasticsearch client configured via command-line flags/layers.
+- **API Calls:** Use the official `elasticsearch-go` client library for making API requests.
+- **Error Handling:** Wrap errors using `github.com/pkg/errors`. Parse Elasticsearch error responses gracefully (using helpers if available, like in `clone.go`).
+- **Output:** Use the `glazed` processor (`gp middlewares.Processor`) to output data in various formats (table, JSON, YAML).
+- **JSON Handling:** Use standard `encoding/json` for parsing policy files and API responses.
+- **Concurrency:** For commands operating on multiple indices (like `explain`, `retry`), consider using `errgroup` for concurrent API calls to improve performance.

--- a/ttmp/2025-04-10/02-index-dump-command-design.md
+++ b/ttmp/2025-04-10/02-index-dump-command-design.md
@@ -1,0 +1,142 @@
+# Design: `escuse-me indices dump` Command
+
+**Date:** 2025-04-10
+
+**Goal:** Create a command to efficiently dump all documents from one or more Elasticsearch indices. The output should be suitable for inspection and potentially re-importing using `escuse-me documents bulk`.
+
+## 1. Core Functionality
+
+The command will retrieve documents from a specified Elasticsearch index (or indices matching a pattern). It needs to handle potentially large indices efficiently without overwhelming memory or hitting Elasticsearch search limits.
+
+The primary mechanism for retrieving large datasets will be the **Point in Time (PIT)** API combined with **`search_after`**.
+
+### What is Point in Time (PIT)?
+
+The PIT API creates a lightweight "frozen" view of the index state at the moment it's created. Think of it as a snapshot marker. When you subsequently search using this PIT ID, you are guaranteed to see the data _exactly_ as it was when the PIT was opened, regardless of any documents being indexed or deleted concurrently.
+
+### Why use PIT for dumping?
+
+When dumping large indices, the process can take time. If documents are being added, updated, or deleted while the dump is in progress, standard pagination methods (like basic `from`/`size`) can become unreliable, potentially skipping documents or returning duplicates. PIT solves this by providing a stable, unchanging view of the data for the duration of the dump.
+
+### How PIT works with `search_after`
+
+`search_after` is an efficient way to retrieve the next "page" of results by using the sort values of the last document from the previous page as a starting point for the next search. Combining PIT and `search_after`:
+
+1.  We open a PIT for the target index, getting back a PIT ID and an initial `keep_alive` duration.
+2.  We perform an initial search using the PIT ID, sorting by `_shard_doc` (a requirement for `search_after`), and retrieve the first batch of documents.
+3.  For subsequent batches, we perform searches using the same PIT ID, the same sort order, and the `search_after` parameter populated with the sort values from the _last_ document of the _previous_ batch.
+4.  Each search using the PIT ID implicitly refreshes its `keep_alive` timer.
+5.  Once all documents are retrieved (or the limit is reached), we explicitly close the PIT to release server resources.
+
+This combination ensures consistent and efficient pagination over large, potentially changing datasets. It is generally preferred over the older `Scroll` API as it's more resource-friendly on the Elasticsearch cluster and stateless on the client side (after the initial PIT creation).
+
+## 2. Command Definition
+
+- **Name:** `escuse-me indices dump`
+- **Parent:** `escuse-me indices`
+- **Short Description:** Dumps documents from an Elasticsearch index.
+- **Long Description:** Retrieves documents from the specified Elasticsearch index(es) using the Point in Time (PIT) API and `search_after` for efficient pagination. Supports filtering via Query DSL and multiple output formats, including one compatible with the `bulk` command.
+
+## 3. Parameters/Flags
+
+Flags will control the source index, filtering, output format, and performance.
+
+**Source & Filtering:**
+
+- `--index` (string, required): The name of the index or index pattern to dump documents from (e.g., `my-index`, `logs-*`).
+- `--query` (string or file path): Path to a JSON/YAML file containing an Elasticsearch Query DSL query object, or the query JSON directly as a string. Defaults to `{"query": {"match_all": {}}}` to retrieve all documents. Allows filtering the documents to be dumped.
+- `--limit` (int): Maximum number of documents to dump. Defaults to `-1` (no limit). Useful for sampling or testing.
+
+**Output Format & Control:**
+
+- `--bulk-format` (bool, default: false):
+  - If `false` (default): Output documents using the standard Glazed processor. Each row will typically represent one document's `_source`. Users can use standard Glazed flags (`-o table`, `-o json`, `-o yaml`, `--output jsonl`, etc.) for formatting. Metadata like `_id` and `_index` can be included using `--fields _id,_index,_source.*`. This is best for inspection.
+  - If `true`: Output documents in the Elasticsearch Bulk API format (alternating action/metadata line and source line). This format is directly consumable by `escuse-me documents bulk`.
+- `--target-index` (string): **Used only when `--bulk-format` is true.** Specifies the index name to use in the bulk action/metadata line. If not provided, defaults to the original index name from which the document was retrieved (`_index` field of the hit). Allows dumping from `index-v1` but formatting it for import into `index-v2`.
+- `--action` (choice: `index`, `create`, default: `index`): **Used only when `--bulk-format` is true.** Specifies the bulk action (`index` or `create`) to use in the action/metadata line.
+- `--include-metadata` (string list): A list of top-level metadata fields (e.g., `_id`, `_index`, `_score`, `_routing`) to include as columns when _not_ using `--bulk-format`. Defaults potentially to `_id`, `_index`. Ignored if `--bulk-format` is true. _(Alternatively, rely solely on Glazed's `--fields` flag)_ Let's rely on `--fields` for simplicity.
+
+**Performance & ES Control:**
+
+- `--batch-size` (int, default: 1000): Number of documents to retrieve per `search` request within the PIT/`search_after` loop. Controls the `size` parameter in the ES query.
+- `--pit-keep-alive` (duration string, default: "5m"): How long the Point in Time context should be kept alive on the Elasticsearch server. Passed to the initial PIT creation request and refreshed implicitly by subsequent `search` calls using it.
+- **Standard ES Connection Flags:** Inherited via the `es-layers` (address, credentials, etc.).
+- **Standard Glazed Flags:** Inherited via `glazed-layers` (output format, fields selection, etc.).
+
+## 4. Output Formats
+
+**Default (Glazed Output, `--bulk-format=false`)**
+
+- Each Elasticsearch document hit results in one row passed to the Glazed processor.
+- By default, the columns might be derived from the `_source` fields.
+- Users can use `--fields _id,_index,_source.field1,_source.field2` etc., to control exactly which parts of the hit are output.
+- Format controlled by `-o`/`--output` (table, json, yaml, jsonl). `jsonl` is often ideal for machine processing.
+
+_Example (`-o jsonl --fields _id,_source.user`)_:
+
+```json
+{"_id": "doc1", "user": "alice"}
+{"_id": "doc2", "user": "bob"}
+```
+
+**Bulk Format (`--bulk-format=true`)**
+
+- Output is plain text, directly usable by the ES Bulk API / `escuse-me documents bulk`.
+- Alternating lines:
+  1.  Action/Metadata JSON: `{"index": {"_index": "target-index-name", "_id": "hit_id"}}` (action and index name controlled by flags)
+  2.  Document Source JSON: `{ "field1": "value1", ... }` (the `_source` of the hit)
+
+_Example (`--bulk-format --target-index my-new-index`)_:
+
+```json
+{"index": {"_index": "my-new-index", "_id": "doc1"}}
+{"user": "alice", "timestamp": "...", ...}
+{"index": {"_index": "my-new-index", "_id": "doc2"}}
+{"user": "bob", "timestamp": "...", ...}
+```
+
+## 5. Implementation Notes
+
+- Use `github.com/go-go-golems/glazed/pkg/cmds` framework.
+- Leverage `es-layers` for ES client setup and connection flags.
+- Leverage `glazed-layers` for output formatting flags.
+- **Core Logic:**
+  1.  Parse flags.
+  2.  Get ES client.
+  3.  Create PIT ID using `client.OpenPointInTime()`. Handle errors.
+  4.  Initialize `search_after` variable (starts as `nil`).
+  5.  Start loop:
+      a. Build `search` request: - Set `pit.id` and `pit.keep_alive`. - Set `size` (`--batch-size`). - Set `query` (from `--query` flag or `match_all`). - Set `sort: [{"_shard_doc": "asc"}]` (required for `search_after`). - Set `search_after` (using value from previous iteration's last hit). - Potentially set `_source_includes`/`_source_excludes` based on Glazed's `--fields` if needed for efficiency (though filtering _after_ fetching might be simpler with Glazed).
+      b. Execute `search` request. Handle errors.
+      c. Check response for hits. If no hits, break loop.
+      d. Process hits: - If `--bulk-format`: Iterate hits, print action line, print `_source` line. - Else (Glazed): Iterate hits, create `types.Row` from `_source` (and potentially other fields based on `--fields`), add row to Glazed processor.
+      e. Update `search_after` variable with the `sort` value from the _last_ hit in the current batch.
+      f. Check `--limit` and break if reached.
+  6.  Close PIT ID using `client.ClosePointInTime()`. Ensure this runs even if the loop breaks early or errors occur (use `defer`).
+- Error handling is crucial, especially around PIT creation/closure and network errors during pagination.
+- Output should go to standard output, allowing redirection (`> dump.jsonl` or `> dump.bulk`).
+
+## 6. Usage Examples
+
+```bash
+# Dump all docs from 'my-index' as JSON Lines (good for jq processing)
+escuse-me indices dump --index my-index -o jsonl > my-index-dump.jsonl
+
+# Dump only docs where user=alice as a table, showing only id and user field
+escuse-me indices dump --index my-index --query '{"query": {"term": {"user": "alice"}}}' \
+  -o table --fields _id,_source.user
+
+# Dump first 100 docs matching a query from 'logs-*' into bulk format for re-import into 'logs-archived'
+escuse-me indices dump --index 'logs-*' --query @filter-query.json --limit 100 \
+  --bulk-format --target-index logs-archived --action create > logs.bulk
+
+# Pipe dump directly to bulk import (re-indexing with filtering)
+escuse-me indices dump --index old-index --query @filter.json --bulk-format --target-index new-index | \
+  escuse-me documents bulk --files -
+```
+
+## 7. Future Considerations
+
+- Support for the older `Scroll` API as a fallback? (Adds complexity, maybe not needed initially).
+- More sophisticated progress indication (e.g., number of documents dumped). Glazed might offer some hooks.
+- Directly specifying fields to include/exclude from `_source` via dedicated flags (though `--fields` might suffice).


### PR DESCRIPTION
This PR adds two powerful new commands for Elasticsearch index management:

## New Commands

* `indices dump`: Efficiently extracts documents from Elasticsearch indices
  * Uses Point-in-Time (PIT) API with search_after for consistent pagination
  * Supports filtering via query DSL
  * Two output modes:
    * Standard output (via Glazed) for inspection/analysis
    * Bulk format compatible with `documents bulk` for re-indexing

* `indices reindex`: Comprehensive interface to Elasticsearch's _reindex API
  * Copies documents between indices with filtering and transformation
  * Supports document transformation via scripts and ingest pipelines
  * Creates target index with custom settings/mappings if needed
  * Monitors progress asynchronously by polling the Tasks API
  * Optionally swaps aliases for zero-downtime index changes

## Documentation

* Added detailed topic guide explaining reindexing concepts
* Created step-by-step tutorial for reindexing with mapping changes
* Included test files for the tutorial

## Other Improvements

* Enhanced `indices stats` with more readable table output and metric filtering
* Improved `indices clone` with automatic read-only mode management
* Renamed `update-aliases` parameter from `--body` to `--actions` for clarity
* Fixed parameter definition in `documents bulk-index`

## Future Work

* Design docs for Index Lifecycle Management (ILM) commands added to `ttmp`
  directory for future implementation reference